### PR TITLE
Fix line count tracking for file overwrites

### DIFF
--- a/agent/piagent/plugin.ts
+++ b/agent/piagent/plugin.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (event, ctx) => {
@@ -16,16 +16,33 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.on("tool_call", async (event, ctx) => {
-    sendToGryph("tool_call", {
+    const result = sendToGryphWithExitCode("tool_call", {
       session_id: ctx.sessionManager.getSessionFile() ?? "ephemeral",
       cwd: ctx.cwd,
       tool_name: event.toolName,
       tool_call_id: event.toolCallId,
       input: event.input,
     });
+
+    // Exit code 2 means block - propagate blocking to Pi Agent
+    if (result.exitCode === 2) {
+      return {
+        block: true,
+        reason: result.stderr || "Blocked by security policy",
+      };
+    }
+
+    // Exit code 1 means error - allow but could log (for now, just allow)
+    // Exit code 0 means allow
   });
 
   pi.on("tool_result", async (event, ctx) => {
+    // Skip tool_result for file operations - tool_call already has all the info
+    // This prevents duplicate events and incorrect stats
+    if (event.toolName === "write" || event.toolName === "edit" || event.toolName === "read") {
+      return;
+    }
+
     sendToGryph("tool_result", {
       session_id: ctx.sessionManager.getSessionFile() ?? "ephemeral",
       cwd: ctx.cwd,
@@ -53,4 +70,26 @@ function sendToGryph(hookType: string, data: Record<string, unknown>) {
   child.stdin.end();
 
   // Fire-and-forget: silently ignore errors
+}
+
+// sendToGryphWithExitCode waits for the gryph hook to complete and returns the exit code.
+// This is required for tool_call hooks where blocking decisions (exit code 2) must be enforced.
+function sendToGryphWithExitCode(hookType: string, data: Record<string, unknown>): {
+  exitCode: number;
+  stderr: string;
+} {
+  const payload = JSON.stringify({
+    hook_event_name: hookType,
+    ...data,
+    timestamp: new Date().toISOString(),
+  });
+
+  // Use spawnSync for synchronous execution to get exit code reliably
+  // This ensures we block tool execution until the hook decision is received
+  const result = spawnSync("__GRYPH_COMMAND__", ["_hook", "pi-agent", hookType], {
+    input: payload,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  return { exitCode: result.status ?? 0, stderr: result.stderr?.toString() ?? "" };
 }


### PR DESCRIPTION
## Problem

When Pi Agent uses the 'write' tool to overwrite a file, it only sends the new content without the old content. This caused gryph to treat every write as a new file creation, missing the `lines_removed` count.

## Solution

- Read existing file content when 'content' is provided but 'oldText' is empty
- Calculate proper `lines_added`/`lines_removed` by diffing old vs new content
- Support both `oldText`/`newText` (Pi Agent) and `old_string`/`new_string` field names
- Add `buildPayloadForResult` to avoid duplicating write details in `tool_result`
- Skip `tool_result` for file operations in plugin.ts to prevent duplicate events
- Add blocking hook support with exit code propagation in plugin.ts
- Add test for edit tool with `oldText`/`newText` fields

## Files Changed

- `agent/piagent/parser.go` - Line count diffing logic
- `agent/piagent/parser_test.go` - Tests for edit tool
- `agent/piagent/plugin.ts` - Blocking hook support, skip duplicate events

## Testing

Verified line counting accuracy with multiple test scenarios:
- Simple file creation (+N -0)
- File replacement (+N -M)
- Sequential edits
- File overwrites
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safedep/gryph/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
