### PR TITLE
PostToolUse hook error when parsing MCP tool responses

### DIFF
--- a/agent/claudecode/parser.go
+++ b/agent/claudecode/parser.go
@@ -159,7 +159,13 @@ func (a *Adapter) parsePreToolUse(sessionID uuid.UUID, agentSessionID string, ba
 func (a *Adapter) parsePostToolUse(sessionID uuid.UUID, agentSessionID string, base HookInput, rawData []byte, isFailure bool) (*events.Event, error) {
 	var input PostToolUseInput
 	if err := json.Unmarshal(rawData, &input); err != nil {
-		return nil, fmt.Errorf("failed to parse PostToolUse input: %w", err)
+		rawData, err = wrapToolResponse(rawData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse PostToolUse input: %w", err)
+		}
+		if err := json.Unmarshal(rawData, &input); err != nil {
+			return nil, fmt.Errorf("failed to parse PostToolUse input after wrapping tool_response: %w", err)
+		}
 	}
 
 	actionType := getActionType(input.ToolName)
@@ -186,6 +192,25 @@ func (a *Adapter) parsePostToolUse(sessionID uuid.UUID, agentSessionID string, b
 	a.markSensitivePaths(event, actionType, input.ToolInput)
 
 	return event, nil
+}
+
+// wrapToolResponse rewrites a non-object tool_response value (array or string
+// from MCP tools) into {"content": <original_value>} so it can be unmarshalled
+// into PostToolUseInput.ToolResponse as map[string]interface{}.
+// Note: This involves an extra unmarshal-marshal cycle which is not ideal for
+// performance, but only executes on the fallback path when tool_response is not
+// a JSON object (i.e. MCP tool responses).
+func wrapToolResponse(rawData []byte) ([]byte, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rawData, &raw); err != nil {
+		return nil, err
+	}
+	wrapped, err := json.Marshal(map[string]json.RawMessage{"content": raw["tool_response"]})
+	if err != nil {
+		return nil, err
+	}
+	raw["tool_response"] = wrapped
+	return json.Marshal(raw)
 }
 
 func parseSessionStart(sessionID uuid.UUID, agentSessionID string, base HookInput, rawData []byte) (*events.Event, error) {

--- a/agent/claudecode/parser.go
+++ b/agent/claudecode/parser.go
@@ -157,6 +157,8 @@ func (a *Adapter) parsePreToolUse(sessionID uuid.UUID, agentSessionID string, ba
 }
 
 func (a *Adapter) parsePostToolUse(sessionID uuid.UUID, agentSessionID string, base HookInput, rawData []byte, isFailure bool) (*events.Event, error) {
+	origRawData := rawData
+
 	var input PostToolUseInput
 	if err := json.Unmarshal(rawData, &input); err != nil {
 		rawData, err = wrapToolResponse(rawData)
@@ -173,7 +175,7 @@ func (a *Adapter) parsePostToolUse(sessionID uuid.UUID, agentSessionID string, b
 	event.AgentSessionID = agentSessionID
 	event.ToolName = input.ToolName
 	event.WorkingDirectory = input.Cwd
-	event.RawEvent = rawData
+	event.RawEvent = origRawData
 
 	if err := a.buildPayload(event, actionType, input.ToolName, input.ToolInput, input.ToolResponse); err != nil {
 		return nil, fmt.Errorf("failed to build payload: %w", err)

--- a/agent/claudecode/parser_test.go
+++ b/agent/claudecode/parser_test.go
@@ -2,6 +2,7 @@ package claudecode
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -174,6 +175,164 @@ func TestParseHookEvent_PostToolUseFailure(t *testing.T) {
 	assert.Equal(t, "Bash", event.ToolName)
 	assert.Equal(t, events.ResultError, event.ResultStatus)
 	assert.Contains(t, event.ErrorMessage, "Command failed")
+}
+
+func TestParseHookEvent_PostToolUseResponseTypes(t *testing.T) {
+	ctx := context.Background()
+	adapter := testAdapter(t)
+
+	tests := []struct {
+		name           string
+		fixture        string
+		hookType       string
+		expectedAction events.ActionType
+		expectedTool   string
+		expectedStatus events.ResultStatus
+		hasOutput      bool
+		checkOutput    func(t *testing.T, output json.RawMessage)
+	}{
+		{
+			name:           "native tool: Read (object response)",
+			fixture:        "post_tool_use_read.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionFileRead,
+			expectedTool:   "Read",
+			expectedStatus: events.ResultSuccess,
+		},
+		{
+			name:           "native tool: Glob (object response)",
+			fixture:        "post_tool_use_glob.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionFileRead,
+			expectedTool:   "Glob",
+			expectedStatus: events.ResultSuccess,
+		},
+		{
+			name:           "native tool: Bash failure (object response)",
+			fixture:        "post_tool_use_failure.json",
+			hookType:       "PostToolUseFailure",
+			expectedAction: events.ActionCommandExec,
+			expectedTool:   "Bash",
+			expectedStatus: events.ResultError,
+		},
+		{
+			name:           "MCP tool: array response (single content block)",
+			fixture:        "post_tool_use_mcp.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionToolUse,
+			expectedTool:   "mcp__Jira__atlassianUserInfo",
+			expectedStatus: events.ResultSuccess,
+			hasOutput:      true,
+			checkOutput: func(t *testing.T, output json.RawMessage) {
+				var obj map[string]interface{}
+				require.NoError(t, json.Unmarshal(output, &obj))
+				assert.Contains(t, obj, "content")
+			},
+		},
+		{
+			name:           "MCP tool: array response (multiple content blocks)",
+			fixture:        "post_tool_use_mcp_multi_content.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionToolUse,
+			expectedTool:   "mcp__docs__search",
+			expectedStatus: events.ResultSuccess,
+			hasOutput:      true,
+			checkOutput: func(t *testing.T, output json.RawMessage) {
+				var obj map[string]interface{}
+				require.NoError(t, json.Unmarshal(output, &obj))
+				content, ok := obj["content"].([]interface{})
+				require.True(t, ok)
+				assert.Len(t, content, 2)
+			},
+		},
+		{
+			name:           "MCP tool: string response (embedded JSON)",
+			fixture:        "post_tool_use_mcp_string.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionToolUse,
+			expectedTool:   "mcp__semaphore__organizations_list",
+			expectedStatus: events.ResultSuccess,
+			hasOutput:      true,
+			checkOutput: func(t *testing.T, output json.RawMessage) {
+				var obj map[string]interface{}
+				require.NoError(t, json.Unmarshal(output, &obj))
+				assert.Contains(t, obj, "content")
+			},
+		},
+		{
+			name:           "MCP tool: string response (plain text)",
+			fixture:        "post_tool_use_mcp_plain_string.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionToolUse,
+			expectedTool:   "mcp__slack__post_message",
+			expectedStatus: events.ResultSuccess,
+			hasOutput:      true,
+			checkOutput: func(t *testing.T, output json.RawMessage) {
+				var obj map[string]interface{}
+				require.NoError(t, json.Unmarshal(output, &obj))
+				assert.Equal(t, "Message posted successfully", obj["content"])
+			},
+		},
+		{
+			name:           "MCP tool: string response (truncated to file path)",
+			fixture:        "post_tool_use_mcp_truncated.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionToolUse,
+			expectedTool:   "mcp__Jira__searchJiraIssuesUsingJql",
+			expectedStatus: events.ResultSuccess,
+			hasOutput:      true,
+			checkOutput: func(t *testing.T, output json.RawMessage) {
+				var obj map[string]interface{}
+				require.NoError(t, json.Unmarshal(output, &obj))
+				assert.Contains(t, obj["content"], "exceeds maximum allowed tokens")
+			},
+		},
+		{
+			name:           "MCP tool: object response (passes through normally)",
+			fixture:        "post_tool_use_mcp_object.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionToolUse,
+			expectedTool:   "mcp__custom__get_status",
+			expectedStatus: events.ResultSuccess,
+			hasOutput:      true,
+			checkOutput: func(t *testing.T, output json.RawMessage) {
+				var obj map[string]interface{}
+				require.NoError(t, json.Unmarshal(output, &obj))
+				assert.Equal(t, "healthy", obj["status"])
+			},
+		},
+		{
+			name:           "MCP tool: null response",
+			fixture:        "post_tool_use_mcp_null_response.json",
+			hookType:       "PostToolUse",
+			expectedAction: events.ActionToolUse,
+			expectedTool:   "mcp__service__ping",
+			expectedStatus: events.ResultSuccess,
+			hasOutput:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := loadFixture(t, tc.fixture)
+			event, err := adapter.ParseEvent(ctx, tc.hookType, data)
+			require.NoError(t, err)
+			require.NotNil(t, event)
+
+			assert.Equal(t, tc.expectedAction, event.ActionType)
+			assert.Equal(t, tc.expectedTool, event.ToolName)
+			assert.Equal(t, tc.expectedStatus, event.ResultStatus)
+
+			if tc.hasOutput {
+				payload, err := event.GetToolUsePayload()
+				require.NoError(t, err)
+				assert.NotEmpty(t, payload.Output)
+				if tc.checkOutput != nil {
+					tc.checkOutput(t, payload.Output)
+				}
+			}
+		})
+	}
 }
 
 func TestParseHookEvent_SessionStart(t *testing.T) {

--- a/agent/claudecode/testdata/post_tool_use_mcp.json
+++ b/agent/claudecode/testdata/post_tool_use_mcp.json
@@ -1,0 +1,16 @@
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "mcp__Jira__atlassianUserInfo",
+  "tool_input": {},
+  "tool_response": [
+    {
+      "type": "text",
+      "text": "{\"displayName\":\"Test User\",\"emailAddress\":\"test@example.com\"}"
+    }
+  ],
+  "tool_use_id": "tool-use-010"
+}

--- a/agent/claudecode/testdata/post_tool_use_mcp_multi_content.json
+++ b/agent/claudecode/testdata/post_tool_use_mcp_multi_content.json
@@ -1,0 +1,22 @@
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "mcp__docs__search",
+  "tool_input": {
+    "query": "authentication"
+  },
+  "tool_response": [
+    {
+      "type": "text",
+      "text": "Found 2 results for authentication"
+    },
+    {
+      "type": "text",
+      "text": "Result 1: OAuth2 setup guide\nResult 2: API key management"
+    }
+  ],
+  "tool_use_id": "tool-use-013"
+}

--- a/agent/claudecode/testdata/post_tool_use_mcp_null_response.json
+++ b/agent/claudecode/testdata/post_tool_use_mcp_null_response.json
@@ -1,0 +1,11 @@
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "mcp__service__ping",
+  "tool_input": {},
+  "tool_response": null,
+  "tool_use_id": "tool-use-014"
+}

--- a/agent/claudecode/testdata/post_tool_use_mcp_object.json
+++ b/agent/claudecode/testdata/post_tool_use_mcp_object.json
@@ -1,0 +1,16 @@
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "mcp__custom__get_status",
+  "tool_input": {
+    "service": "api"
+  },
+  "tool_response": {
+    "status": "healthy",
+    "uptime": 86400
+  },
+  "tool_use_id": "tool-use-016"
+}

--- a/agent/claudecode/testdata/post_tool_use_mcp_plain_string.json
+++ b/agent/claudecode/testdata/post_tool_use_mcp_plain_string.json
@@ -1,0 +1,14 @@
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "mcp__slack__post_message",
+  "tool_input": {
+    "channel": "general",
+    "message": "hello"
+  },
+  "tool_response": "Message posted successfully",
+  "tool_use_id": "tool-use-015"
+}

--- a/agent/claudecode/testdata/post_tool_use_mcp_string.json
+++ b/agent/claudecode/testdata/post_tool_use_mcp_string.json
@@ -1,0 +1,11 @@
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "mcp__semaphore__organizations_list",
+  "tool_input": {},
+  "tool_response": "{\"organizations\":[{\"id\":\"abc-123\",\"name\":\"test-org\"}]}",
+  "tool_use_id": "tool-use-011"
+}

--- a/agent/claudecode/testdata/post_tool_use_mcp_truncated.json
+++ b/agent/claudecode/testdata/post_tool_use_mcp_truncated.json
@@ -1,0 +1,13 @@
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "mcp__Jira__searchJiraIssuesUsingJql",
+  "tool_input": {
+    "jql": "reporter = currentUser()"
+  },
+  "tool_response": "Error: result (319260 characters) exceeds maximum allowed tokens. Output has been saved to /tmp/tool-results/mcp-result-123.txt.",
+  "tool_use_id": "tool-use-012"
+}


### PR DESCRIPTION
## Issue

Claude Code `PostToolUse` hooks fail to parse MCP tool responses. The `tool_response` field is documented as a JSON object but MCP tools return arrays or strings, causing `json: cannot unmarshal array into Go struct field PostToolUseInput.tool_response of type map[string]interface{}`.

## Proposed Fix

On unmarshal failure, wrap the raw `tool_response` as `{"content": <original_value>}` and retry. Built-in tools (always objects) take the happy path with no overhead.

### Impact

- MCP tool responses are now stored in the local SQLite DB, increasing DB size proportional to MCP usage
- Follow-up needed for truncated large responses (Claude Code writes these to temp files)

## Alternate Fixes

- Catch the unmarshal error and store the event without `tool_response` data. MCP responses are already in Claude Code session transcripts (JSONL), so gryph could read them on demand instead of duplicating in the DB. Avoids DB growth but depends on transcript file availability.

## Testing

- 10-case table-driven test covering native tools (Read, Glob, Bash failure) and MCP variants (array, multi-block array, JSON string, plain string, truncated path, object, null)
- Integration tested with 4 MCP servers + native tools
- `make test` and `make lint` pass