### PR TITLE
feat(claudecode): wire DecisionGuidance through to hook output

### DIFF
--- a/agent/claudecode/parser.go
+++ b/agent/claudecode/parser.go
@@ -465,6 +465,9 @@ const (
 	HookBlock
 	// HookError is a non-blocking error (exit code 1, message to stderr, shown to user in verbose mode).
 	HookError
+	// HookGuidance allows the action but emits advisory text to stderr (exit code 0, stderr shown to user in verbose mode).
+	// Used when a security check returns DecisionGuidance — advisory, not blocking.
+	HookGuidance
 )
 
 // HookResponse represents a response to Claude Code hooks.
@@ -476,7 +479,7 @@ type HookResponse struct {
 }
 
 // ExitCode returns the exit code for this response.
-// Exit code 0 = allow, exit code 2 = block, exit code 1 = non-blocking error.
+// Exit code 0 = allow (or guidance), exit code 2 = block, exit code 1 = non-blocking error.
 func (r *HookResponse) ExitCode() int {
 	switch r.Decision {
 	case HookBlock:
@@ -484,16 +487,20 @@ func (r *HookResponse) ExitCode() int {
 	case HookError:
 		return 1
 	default:
+		// HookAllow and HookGuidance both exit 0 (guidance is non-blocking).
 		return 0
 	}
 }
 
-// Stderr returns the message to write to stderr (for blocking and error).
+// Stderr returns the message to write to stderr.
+// Written for HookBlock (shown to Claude), HookError (verbose mode), and HookGuidance (advisory, verbose mode).
 func (r *HookResponse) Stderr() string {
-	if r.Decision == HookBlock || r.Decision == HookError {
+	switch r.Decision {
+	case HookBlock, HookError, HookGuidance:
 		return r.Message
+	default:
+		return ""
 	}
-	return ""
 }
 
 // NewAllowResponse creates a response that allows the action.
@@ -515,6 +522,16 @@ func NewBlockResponse(message string) *HookResponse {
 func NewErrorResponse(message string) *HookResponse {
 	return &HookResponse{
 		Decision: HookError,
+		Message:  message,
+	}
+}
+
+// NewGuidanceResponse creates a non-blocking advisory response.
+// Exit code 0 (allow); message shown to user in verbose mode. Used when
+// a security check returns DecisionGuidance — advisory, not blocking.
+func NewGuidanceResponse(message string) *HookResponse {
+	return &HookResponse{
+		Decision: HookGuidance,
 		Message:  message,
 	}
 }

--- a/agent/claudecode/parser_test.go
+++ b/agent/claudecode/parser_test.go
@@ -471,6 +471,7 @@ func TestHookResponse_ExitCodes(t *testing.T) {
 		{"Allow", NewAllowResponse(), 0},
 		{"Block", NewBlockResponse("blocked"), 2},
 		{"Error", NewErrorResponse("error"), 1},
+		{"Guidance", NewGuidanceResponse("advisory"), 0},
 	}
 
 	for _, tc := range testCases {
@@ -489,4 +490,7 @@ func TestHookResponse_Stderr(t *testing.T) {
 
 	errResp := NewErrorResponse("error message")
 	assert.Equal(t, "error message", errResp.Stderr())
+
+	guidance := NewGuidanceResponse("advisory note")
+	assert.Equal(t, "advisory note", guidance.Stderr())
 }

--- a/cli/hook.go
+++ b/cli/hook.go
@@ -178,6 +178,9 @@ func runHook(ctx context.Context, app *App, agentName, hookType string, rawData 
 		}
 	}
 
+	if securityResult.FinalDecision == security.DecisionGuidance {
+		return sendSecurityGuidanceResponse(agentName, hookType, securityResult)
+	}
 	return sendHookResponse(agentName, hookType)
 }
 
@@ -291,6 +294,25 @@ func sendHookResponse(agentName, hookType string) error {
 	default:
 		// Unknown agent, just succeed
 		return nil
+	}
+}
+
+// sendSecurityGuidanceResponse emits advisory guidance from security checks.
+// The event itself is allowed (exit 0), but aggregated guidance text is
+// written to the agent's stderr. Modelled on sendSecurityBlockedResponse;
+// only agents whose hook packages implement a Guidance response are wired
+// up here. Other agents fall through to the normal allow path.
+func sendSecurityGuidanceResponse(agentName, hookType string, result *security.Result) error {
+	switch agentName {
+	case agent.AgentClaudeCode:
+		response := claudecode.NewGuidanceResponse(result.AggregatedGuidance())
+		return handleClaudeCodeResponse(response)
+
+	default:
+		// Other agents don't yet have a guidance wiring — fall through to
+		// the allow response (the evaluator already marked the event
+		// allowed; we simply don't surface the guidance text).
+		return sendHookResponse(agentName, hookType)
 	}
 }
 
@@ -479,6 +501,14 @@ func handleClaudeCodeResponse(response *claudecode.HookResponse) error {
 	case claudecode.HookError:
 		// Exit code 1: non-blocking error, message shown to user in verbose mode
 		return &exitError{code: 1, message: response.Message}
+
+	case claudecode.HookGuidance:
+		// Exit code 0 (allow), but aggregated guidance is written to stderr
+		// for the user. Matches the evaluator's three-valued decision model.
+		if response.Message != "" {
+			fmt.Fprintln(os.Stderr, response.Message)
+		}
+		return nil
 
 	default:
 		// Exit code 0: allow


### PR DESCRIPTION
The security evaluator in `core/security/` supports a three-valued decision model: Allow, Block, and Guidance. The Evaluator aggregates guidance messages across all registered Checks and sets `FinalDecision = DecisionGuidance` when any Check emits advisory text (`Result.HasGuidance()` / `Result.AggregatedGuidance()` expose this).

However, the Claude Code hook output path has only serialised two outcomes: Allow (exit 0) and Block (exit 2 + stderr). `DecisionGuidance` results were collected by the evaluator and silently discarded — the guidance text never reached the user or the agent.

This change completes the model so `DecisionGuidance` produces exit 0 with the aggregated guidance text on stderr — non-blocking, but visible — matching the design intent of the three-valued evaluator.

## Changes

- `claudecode.HookDecision`: add a `HookGuidance` variant.
- `HookResponse.ExitCode()` returns 0 for `HookGuidance` (non-blocking).
- `HookResponse.Stderr()` returns the message for `HookGuidance`.
- `NewGuidanceResponse(message)` constructor, symmetric with the existing `NewAllowResponse` / `NewBlockResponse` / `NewErrorResponse`.
- `cli/hook.go`: new `sendSecurityGuidanceResponse`, modelled on `sendSecurityBlockedResponse`. `runHook` routes `DecisionGuidance` through it after normal allow-path event-save logic. `handleClaudeCodeResponse` gains a `HookGuidance` case that writes the message to stderr and returns `nil` for exit 0.

Only Claude Code is wired in this change. Other agents fall back to the existing allow path if a Check emits Guidance — adding handlers for the other seven agents is straightforward follow-up work, mirroring the Claude Code pattern.

## Tests

- `TestHookResponse_ExitCodes` gains a `Guidance → 0` case.
- `TestHookResponse_Stderr` gains a `Guidance → message` assertion.
- Existing Allow / Block / Error assertions unchanged and still pass.
- Full `go test ./...` is green across all 19 packages.

## Backward compatibility

Unchanged for every existing path. Checks that return `DecisionAllow` or `DecisionBlock` continue to behave identically. Guidance was previously dead code; enabling it is strictly additive.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safedep/gryph/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
