### PR TITLE
feat(cli): add RegisterCheckFactory extension point for external binaries

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -73,6 +73,15 @@ func NewApp(cfg *config.Config) (*App, error) {
 	sec := security.New(&security.Config{FailOpen: true})
 	sec.RegisterCheck(securitychecks.NewPlaceholderCheck())
 
+	// Invoke any check factories that external binaries registered during
+	// init() via RegisterCheckFactory. Factories that return nil are
+	// skipped so callers can conditionally opt out based on config.
+	for _, f := range checkFactories {
+		if c := f(cfg); c != nil {
+			sec.RegisterCheck(c)
+		}
+	}
+
 	return &App{
 		Config:         cfg,
 		Registry:       registry,
@@ -103,6 +112,31 @@ func (a *App) Close() error {
 		return a.Store.Close()
 	}
 	return nil
+}
+
+// checkFactories is the registry of external security-check factories.
+// External binaries composing gryph as a library call RegisterCheckFactory
+// during init() to add Checks that NewApp will register on the security
+// evaluator alongside the built-in placeholder check.
+var checkFactories []func(cfg *config.Config) security.Check
+
+// RegisterCheckFactory registers a factory that produces a security.Check.
+// Intended for external binaries that import gryph as a library and want to
+// contribute additional security checks without modifying this package.
+//
+// Call order: typically from init() in a package blank-imported by the
+// external binary's main. Each registered factory is invoked once per
+// NewApp() call, and the returned Check (if non-nil) is added to the
+// evaluator. Factories that return nil are ignored — this lets callers
+// conditionally enable/disable checks based on the provided *config.Config.
+//
+// This function is not safe for concurrent use. Register factories before
+// any goroutine calls NewApp.
+func RegisterCheckFactory(f func(cfg *config.Config) security.Check) {
+	if f == nil {
+		return
+	}
+	checkFactories = append(checkFactories, f)
 }
 
 // GlobalFlags holds the global command flags.

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/safedep/gryph/config"
+	"github.com/safedep/gryph/core/events"
+	"github.com/safedep/gryph/core/security"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCheck is a minimal security.Check implementation used to exercise
+// the check factory registration path in NewApp.
+type testCheck struct {
+	name     string
+	decision security.Decision
+	reason   string
+	guidance string
+}
+
+func (c *testCheck) Name() string  { return c.name }
+func (c *testCheck) Enabled() bool { return true }
+func (c *testCheck) Check(ctx context.Context, _ *events.Event) (*security.CheckResult, error) {
+	return &security.CheckResult{
+		Decision:  c.decision,
+		Reason:    c.reason,
+		Guidance:  c.guidance,
+		CheckName: c.name,
+	}, nil
+}
+
+// withCleanFactories isolates a test from other tests' RegisterCheckFactory
+// calls by saving and restoring the package-level checkFactories slice.
+func withCleanFactories(t *testing.T) {
+	t.Helper()
+	prev := checkFactories
+	t.Cleanup(func() { checkFactories = prev })
+	checkFactories = nil
+}
+
+func TestRegisterCheckFactory_RegisteredCheckIsInvoked(t *testing.T) {
+	withCleanFactories(t)
+
+	RegisterCheckFactory(func(cfg *config.Config) security.Check {
+		return &testCheck{
+			name:     "extension-block",
+			decision: security.DecisionBlock,
+			reason:   "factory-registered block for test",
+		}
+	})
+
+	app, err := NewApp(config.Default())
+	require.NoError(t, err)
+	require.NotNil(t, app.Security)
+
+	result := app.Security.Evaluate(context.Background(), &events.Event{})
+	assert.False(t, result.IsAllowed(), "registered factory's blocking check should block evaluation")
+	assert.Equal(t, "factory-registered block for test", result.BlockReason)
+	assert.Equal(t, "extension-block", result.BlockedBy)
+}
+
+func TestRegisterCheckFactory_NilFactoryReturnIsIgnored(t *testing.T) {
+	withCleanFactories(t)
+
+	RegisterCheckFactory(func(cfg *config.Config) security.Check {
+		return nil
+	})
+
+	app, err := NewApp(config.Default())
+	require.NoError(t, err)
+
+	// Only the built-in PlaceholderCheck should be active; it always allows.
+	result := app.Security.Evaluate(context.Background(), &events.Event{})
+	assert.True(t, result.IsAllowed(), "nil factory return should not register any check")
+}
+
+func TestRegisterCheckFactory_NilFunctionIsIgnored(t *testing.T) {
+	withCleanFactories(t)
+
+	// Registering a nil function is a caller bug, but we must not crash
+	// or pollute the registry.
+	RegisterCheckFactory(nil)
+
+	app, err := NewApp(config.Default())
+	require.NoError(t, err)
+
+	result := app.Security.Evaluate(context.Background(), &events.Event{})
+	assert.True(t, result.IsAllowed())
+}
+
+func TestNewApp_NoFactoriesStillBuildsCleanly(t *testing.T) {
+	withCleanFactories(t)
+
+	// Backward compatibility: if nobody registers a factory, NewApp behaves
+	// exactly as it did before the extension point existed.
+	app, err := NewApp(config.Default())
+	require.NoError(t, err)
+	require.NotNil(t, app.Security)
+
+	result := app.Security.Evaluate(context.Background(), &events.Event{})
+	assert.True(t, result.IsAllowed())
+}
+
+func TestRegisterCheckFactory_MultipleFactoriesAllInvoked(t *testing.T) {
+	withCleanFactories(t)
+
+	// Two factories, first allows, second blocks. Evaluator short-circuits
+	// on the first block, so we expect blocked-by to be the second factory.
+	RegisterCheckFactory(func(cfg *config.Config) security.Check {
+		return &testCheck{name: "factory-a-allow", decision: security.DecisionAllow}
+	})
+	RegisterCheckFactory(func(cfg *config.Config) security.Check {
+		return &testCheck{
+			name:     "factory-b-block",
+			decision: security.DecisionBlock,
+			reason:   "second factory blocks",
+		}
+	})
+
+	app, err := NewApp(config.Default())
+	require.NoError(t, err)
+
+	result := app.Security.Evaluate(context.Background(), &events.Event{})
+	assert.False(t, result.IsAllowed())
+	assert.Equal(t, "factory-b-block", result.BlockedBy)
+}


### PR DESCRIPTION
Exposes a package-level registry so binaries that import gryph as a library can contribute additional `security.Check` implementations without modifying `cli/root.go`. Follows the standard Go composition pattern used by `database/sql.Register`, `image/png` decoder registration, and similar stdlib extension points.

## Changes

- `cli.RegisterCheckFactory(f)` appends a factory to a package-level slice. Safe to call from `init()` of blank-imported packages.
- `NewApp` iterates registered factories after constructing the security evaluator and adds each returned Check alongside the built-in `PlaceholderCheck`. Factories that return `nil` are ignored so callers can conditionally opt out based on configuration.
- Nil function arguments to `RegisterCheckFactory` are rejected defensively rather than panicking later.

## Motivation

External binaries composing gryph as a library (e.g. an org-specific hook tool with domain-specific policy checks) currently have no clean way to add Checks — the only registration point is inside `NewApp` itself, which is called from an unexported `loadApp` during `_hook` subcommand dispatch. The options today are either (a) fork and patch `cli/root.go`, which diverges from upstream, or (b) replace `NewHookCmd` wholesale by duplicating `runHook`, which duplicates hundreds of lines of internal event-processing logic. Neither is healthy.

A package-level factory registry is the smallest addition that enables clean composition. The Go stdlib uses this pattern extensively (drivers, codecs, encoders). No new configuration surface, no new dependencies, no API changes for existing callers.

## Tests

`cli/root_test.go` (new file — first test under `cli/`):

- `TestRegisterCheckFactory_RegisteredCheckIsInvoked` verifies a blocking factory's check actually participates in evaluation.
- `TestRegisterCheckFactory_NilFactoryReturnIsIgnored` verifies factories returning nil produce no registration.
- `TestRegisterCheckFactory_NilFunctionIsIgnored` verifies nil function arguments are rejected without crashing.
- `TestNewApp_NoFactoriesStillBuildsCleanly` is the explicit backward-compatibility assertion.
- `TestRegisterCheckFactory_MultipleFactoriesAllInvoked` verifies multiple registrations compose correctly.

All tests isolate themselves via a `t.Cleanup` helper that saves and restores the package-level factory slice.

## Backward compatibility

Strictly additive. When no factories are registered the evaluator behaves exactly as before — only the `PlaceholderCheck` is active and evaluation always allows. The full pre-existing test suite is unaffected.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/safedep/gryph/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
