### PR TITLE
fix: respect XDG env vars across platforms, and show configured DB path in user-facing commands

### DIFF
--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -44,7 +44,7 @@ Performs various health checks:
 					Name:        "Database file",
 					Description: "Check if database file exists and is accessible",
 				}
-				if _, err := os.Stat(app.Paths.DatabaseFile); os.IsNotExist(err) {
+				if _, err := os.Stat(app.Config.GetDatabasePath()); os.IsNotExist(err) {
 					dbCheck.Status = tui.CheckFail
 					dbCheck.Message = "Database file not found"
 					dbCheck.Suggestion = "Run 'gryph install' to initialize"
@@ -55,7 +55,7 @@ Performs various health checks:
 					v.AllOK = false
 				} else {
 					dbCheck.Status = tui.CheckOK
-					dbCheck.Message = app.Paths.DatabaseFile
+					dbCheck.Message = app.Config.GetDatabasePath()
 				}
 				v.Checks = append(v.Checks, dbCheck)
 

--- a/cli/install.go
+++ b/cli/install.go
@@ -73,7 +73,7 @@ to enable audit logging. Existing hooks are backed up by default.`,
 
 			view, err := tui.RunWithSpinner(spinnerMsg, func() (*tui.InstallView, error) {
 				v := &tui.InstallView{
-					Database: app.Paths.DatabaseFile,
+					Database: app.Config.GetDatabasePath(),
 					Config:   app.Paths.ConfigFile,
 				}
 

--- a/cli/paths_test.go
+++ b/cli/paths_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApp_DisplayedDatabasePath_HonorsConfigOverride is a regression test
+// for the bug where status, doctor, install, and uninstall displayed the
+// resolved default database path (from config.ResolvePaths) instead of the
+// path configured via storage.path in config.yaml.
+//
+// The actual DB operations (InitStore) already used Config.GetDatabasePath()
+// correctly, so the data landed at the overridden location — but the user-
+// visible messages and log entries pointed at the default path, misleading
+// operators about where their data actually lives.
+//
+// The fix replaces app.Paths.DatabaseFile with app.Config.GetDatabasePath()
+// at every display / operational callsite. This test asserts the invariant:
+// once storage.path is set, the config-aware path differs from the resolved
+// default, and the two MUST NOT be used interchangeably.
+func TestApp_DisplayedDatabasePath_HonorsConfigOverride(t *testing.T) {
+	cfg := config.Default()
+	cfg.Storage.Path = "/tmp/gryph-test-override.db"
+
+	app, err := NewApp(cfg)
+	require.NoError(t, err)
+	defer func() {
+		_ = app.Close()
+	}()
+
+	// The config-aware path is what status, doctor, install, and uninstall
+	// must display and operate on.
+	assert.Equal(t, "/tmp/gryph-test-override.db", app.Config.GetDatabasePath())
+
+	// The Paths.DatabaseFile is still the resolved platform default — that
+	// is correct for callers that explicitly want the default, but it is
+	// NOT what the user-facing commands should show when an override is
+	// configured. Guard against a regression that silently swaps the two.
+	assert.NotEqual(t, "/tmp/gryph-test-override.db", app.Paths.DatabaseFile,
+		"Paths.DatabaseFile must remain the resolved default; user-facing "+
+			"callsites must use Config.GetDatabasePath() instead")
+}
+
+// TestApp_DisplayedDatabasePath_DefaultsAlignWhenNoOverride documents that
+// the two paths agree when storage.path is not set, so the fix is a no-op
+// for the common case.
+func TestApp_DisplayedDatabasePath_DefaultsAlignWhenNoOverride(t *testing.T) {
+	cfg := config.Default()
+	// Storage.Path intentionally left empty.
+
+	app, err := NewApp(cfg)
+	require.NoError(t, err)
+	defer func() {
+		_ = app.Close()
+	}()
+
+	assert.Equal(t, app.Paths.DatabaseFile, app.Config.GetDatabasePath())
+}

--- a/cli/status.go
+++ b/cli/status.go
@@ -65,10 +65,10 @@ Displays the current status of the tool including:
 
 				// Database info
 				v.Database = tui.DatabaseView{
-					Location: app.Paths.DatabaseFile,
+					Location: app.Config.GetDatabasePath(),
 				}
 
-				if stat, err := os.Stat(app.Paths.DatabaseFile); err == nil {
+				if stat, err := os.Stat(app.Config.GetDatabasePath()); err == nil {
 					v.Database.SizeBytes = stat.Size()
 					v.Database.SizeHuman = tui.FormatBytes(stat.Size())
 

--- a/cli/uninstall.go
+++ b/cli/uninstall.go
@@ -121,14 +121,14 @@ removes the database and configuration files as well.`,
 				// Log purge before removing files
 				if err := logSelfAudit(ctx, app.Store, SelfAuditActionPurge, "",
 					map[string]interface{}{
-						"database_removed": app.Paths.DatabaseFile,
+						"database_removed": app.Config.GetDatabasePath(),
 						"config_removed":   app.Paths.ConfigFile,
 					},
 					SelfAuditResultSuccess, ""); err != nil {
 					return fmt.Errorf("failed to log self-audit: %w", err)
 				}
 
-				if err := os.Remove(app.Paths.DatabaseFile); err != nil {
+				if err := os.Remove(app.Config.GetDatabasePath()); err != nil {
 					log.Errorf("failed to remove database file: %w", err)
 				}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -332,6 +332,58 @@ func TestResolvePaths(t *testing.T) {
 	assert.Contains(t, paths.BackupsDir, "backups")
 }
 
+func TestGetConfigDir_XDGConfigHomeHonored(t *testing.T) {
+	// XDG_CONFIG_HOME must be respected on every platform, not just Linux.
+	// Go's os.UserConfigDir honors it on Linux but returns
+	// ~/Library/Application Support on macOS and %AppData% on Windows,
+	// so this behaviour has to be explicit in gryph.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	got := getConfigDir()
+	assert.Equal(t, filepath.Join(tmpDir, "gryph"), got)
+}
+
+func TestGetConfigDir_PrefersExistingXDGConfigDir(t *testing.T) {
+	// When XDG_CONFIG_HOME is unset but the user has opted into the XDG
+	// layout by creating ~/.config/gryph, prefer that over the platform
+	// default (macOS: ~/Library/Application Support, Windows: %AppData%).
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	xdgConfig := filepath.Join(tmpHome, ".config", "gryph")
+	require.NoError(t, os.MkdirAll(xdgConfig, 0o700))
+
+	got := getConfigDir()
+	assert.Equal(t, xdgConfig, got)
+}
+
+func TestGetDataDir_XDGDataHomeHonored(t *testing.T) {
+	// Same rationale as XDG_CONFIG_HOME: the previous implementation only
+	// consulted XDG_DATA_HOME on Linux. Respect it on macOS and Windows too.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	got := getDataDir()
+	assert.Equal(t, filepath.Join(tmpDir, "gryph"), got)
+}
+
+func TestGetDataDir_PrefersExistingXDGDataDir(t *testing.T) {
+	// Without XDG_DATA_HOME, if ~/.local/share/gryph already exists the
+	// user has opted into the XDG layout and we return that path on every
+	// platform. Without the directory, platform defaults still apply.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	xdgData := filepath.Join(tmpHome, ".local", "share", "gryph")
+	require.NoError(t, os.MkdirAll(xdgData, 0o700))
+
+	got := getDataDir()
+	assert.Equal(t, xdgData, got)
+}
+
 func TestEnsureDirectories(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/config/paths.go
+++ b/config/paths.go
@@ -7,7 +7,27 @@ import (
 )
 
 // getConfigDir returns the configuration directory for gryph.
+//
+// Resolution order:
+//  1. $XDG_CONFIG_HOME/gryph if the environment variable is set (all platforms).
+//     Go's os.UserConfigDir honors this on Linux but not on macOS or Windows;
+//     we extend it to all platforms so users who organize their configs under
+//     an XDG-style layout get a consistent location across systems.
+//  2. $HOME/.config/gryph if that directory already exists (all platforms).
+//     This lets users who have opted into the XDG layout on macOS/Windows
+//     keep their configs in one place without setting an environment variable.
+//  3. Platform default via os.UserConfigDir (Linux $XDG_CONFIG_HOME or
+//     $HOME/.config, macOS $HOME/Library/Application Support, Windows %AppData%).
 func getConfigDir() string {
+	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
+		return filepath.Join(xdgConfig, "gryph")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		xdgDefault := filepath.Join(home, ".config", "gryph")
+		if info, err := os.Stat(xdgDefault); err == nil && info.IsDir() {
+			return xdgDefault
+		}
+	}
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		// Fallback to home directory
@@ -18,14 +38,29 @@ func getConfigDir() string {
 }
 
 // getDataDir returns the data directory for gryph.
-// This follows XDG on Linux, Application Support on macOS, and LocalAppData on Windows.
+//
+// Resolution order:
+//  1. $XDG_DATA_HOME/gryph if the environment variable is set (all platforms).
+//     Mirrors the config-dir behaviour above — respect the XDG base dir spec
+//     everywhere, not just on Linux, for users who want a single layout.
+//  2. $HOME/.local/share/gryph if that directory already exists (all
+//     platforms), for users who have opted into the XDG layout on
+//     macOS/Windows without setting environment variables.
+//  3. Platform default: Linux $HOME/.local/share, macOS $HOME/Library/
+//     Application Support, Windows %LocalAppData%.
 func getDataDir() string {
+	if xdgData := os.Getenv("XDG_DATA_HOME"); xdgData != "" {
+		return filepath.Join(xdgData, "gryph")
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		xdgDefault := filepath.Join(home, ".local", "share", "gryph")
+		if info, err := os.Stat(xdgDefault); err == nil && info.IsDir() {
+			return xdgDefault
+		}
+	}
+
 	switch runtime.GOOS {
 	case "linux":
-		// Follow XDG Base Directory Specification
-		if xdgData := os.Getenv("XDG_DATA_HOME"); xdgData != "" {
-			return filepath.Join(xdgData, "gryph")
-		}
 		home, _ := os.UserHomeDir()
 		return filepath.Join(home, ".local", "share", "gryph")
 


### PR DESCRIPTION
## Summary

Two focused bug fixes, bundled because they share a theme (configured values not reaching the user) and because they touch adjacent code. Split across two commits for reviewer clarity; either can be reverted independently.

### Commit 1 — `fix(config)`: XDG env vars on every platform

Go's `os.UserConfigDir` honors `XDG_CONFIG_HOME` on Linux but returns `~/Library/Application Support` on macOS and `%AppData%` on Windows. Similarly `config.getDataDir` only consulted `XDG_DATA_HOME` on Linux. Users who organise their configs under `$HOME/.config` and `$HOME/.local/share` on every platform had no way to point gryph at that layout without patching the source.

This change:
1. Honors `$XDG_CONFIG_HOME/gryph` and `$XDG_DATA_HOME/gryph` on every platform when set.
2. Prefers `$HOME/.config/gryph` / `$HOME/.local/share/gryph` if those dirs already exist (opt-in with no env var).
3. Falls through to the pre-existing platform default otherwise — existing installs see no change.

Four tests added in `config/config_test.go`, all using `t.Setenv` and `t.TempDir`.

### Commit 2 — `fix(cli)`: display configured DB path, not resolved default

`App` carries two paths: `Paths.DatabaseFile` (resolved default from `config.ResolvePaths`) and `Config.GetDatabasePath()` (honors `storage.path`). `InitStore` already uses the config-aware path when opening SQLite, so data lands at the overridden location — but `status`, `doctor`, `install`, and `uninstall` were reading `Paths.DatabaseFile` directly, so users who configured `storage.path` saw messages pointing at the default path gryph wasn't using.

The most user-visible symptom: `gryph doctor` could report the DB missing while gryph was actively writing to the overridden path, and — more insidiously — could report the DB **present** at the default path while the user's configured override pointed elsewhere. `gryph uninstall --purge` could also silently fail to remove a file that never existed at the default path.

Fix is mechanical: replace `app.Paths.DatabaseFile` with `app.Config.GetDatabasePath()` at each user-facing callsite (6 sites across 4 files). `Paths.DatabaseFile` is retained; it remains correct for any caller that explicitly wants the resolved default.

Two regression tests added in `cli/paths_test.go`.

## Test plan

### Unit tests
- [x] `go test ./config/... -run 'TestGetConfigDir|TestGetDataDir|TestResolvePaths|TestEnsureDirectories|TestConfig_GetDatabasePath' -v` — 8 tests pass
- [x] `go test ./cli/... -run TestApp_DisplayedDatabasePath -v` — 2 tests pass
- [x] `go test ./...` — 20 packages green
- [x] `go build ./...` — clean

### Real-world verification on macOS (darwin/arm64)

Built the PR binary to `/tmp/gryph-pr3` (so the active hook pipeline was untouched) and exercised the four claimed behaviours against a real filesystem. All six cases behaved as the fix promises:

| # | Scenario | Expected | Observed |
|---|---|---|---|
| 1 | `XDG_CONFIG_HOME=/tmp/xdg-test /tmp/gryph-pr3 status` with `storage.path: /tmp/xdg-test/audit.db` in the XDG config | status displays `/tmp/xdg-test/audit.db` as the DB location and `/tmp/xdg-test/gryph/config.yaml` as the config location | ✅ exactly that |
| 2 | `/tmp/gryph-pr3 status` with no XDG env var, on a Mac where `~/.config/gryph/` does not exist but `~/.local/share/gryph/` does | config falls through to platform default (`~/Library/Application Support/gryph/config.yaml`); data location prefers the existing `~/.local/share/gryph/audit.db` | ✅ exactly that |
| 3 | `XDG_CONFIG_HOME=/tmp/xdg-test /tmp/gryph-pr3 doctor` with `storage.path: /tmp/xdg-test/audit.db` and no such file yet | doctor reports "Database file not found" | ✅ |
| 4 | same as #3 but with `storage.path: /tmp/does-not-exist/audit.db` | doctor still reports "Database file not found" (differentiated only by path internally; message is generic today) | ✅ |
| 5 | `touch /tmp/xdg-test/audit.db` then rerun doctor with the override | doctor reports `[ok] Database file /tmp/xdg-test/audit.db` — the override path is displayed | ✅ exactly that |
| 6 | **differential test**: `storage.path` points at `/tmp/xdg-test/audit.db` (doesn't exist); meanwhile the *default* path `~/.local/share/gryph/audit.db` exists with real data | post-fix: doctor reports not-found at the override; pre-fix behaviour would have stat'd the default, reported OK, and misled the operator | ✅ post-fix reports not-found correctly |

Case #6 is the one that isolates the bug: before the fix, doctor would have returned a confident OK based on the wrong file. After the fix, it looks at the right file. This matches the reported symptom.

A small follow-up this PR does **not** include: the doctor "file not found" branch does not echo the path it tried. That's a separate UX improvement and can be filed as its own PR if desired.
