### PR TITLE
fix: use PowerShell Expand-Archive on Windows for npm install

### DIFF
--- a/publish/npm/install.js
+++ b/publish/npm/install.js
@@ -109,7 +109,16 @@ function extractArchive(archivePath, extractDir) {
   const isZip = archivePath.endsWith(".zip");
 
   if (isZip) {
-    execSync(`unzip -o "${archivePath}" -d "${extractDir}"`, { stdio: "pipe" });
+    if (process.platform === "win32") {
+      execSync(
+        `powershell -NoProfile -Command "Expand-Archive -Force -Path '${archivePath}' -DestinationPath '${extractDir}'"`,
+        { stdio: "pipe" },
+      );
+    } else {
+      execSync(`unzip -o "${archivePath}" -d "${extractDir}"`, {
+        stdio: "pipe",
+      });
+    }
   } else {
     execSync(`tar -xzf "${archivePath}" -C "${extractDir}"`, { stdio: "pipe" });
   }


### PR DESCRIPTION
Windows does not have unzip by default, causing npm install to fail. Uses PowerShell Expand-Archive on win32, same fix as safedep/pmg#190.

<img width="1599" height="1200" alt="WhatsApp Image 2026-05-05 at 3 26 45 PM" src="https://github.com/user-attachments/assets/7ee530fc-120e-4d7d-9df7-683d87757187" />

**After fix**
<img width="763" height="243" alt="image" src="https://github.com/user-attachments/assets/018cfeb1-8fbf-4e77-a103-db538fff7a93" />
