### PR TITLE
feat: add Devin CLI agent adapter

### DIFF
--- a/agent/adapter.go
+++ b/agent/adapter.go
@@ -17,6 +17,7 @@ const (
 	AgentWindsurf   = "windsurf"
 	AgentPiAgent    = "pi-agent"
 	AgentCodex      = "codex"
+	AgentDevin      = "devin"
 )
 
 // Standard agent display names.
@@ -29,6 +30,7 @@ const (
 	DisplayWindsurf   = "Windsurf"
 	DisplayPiAgent    = "Pi Agent"
 	DisplayCodex      = "Codex"
+	DisplayDevin      = "Devin"
 )
 
 // AgentDisplayName returns the display name for an agent identifier.
@@ -50,6 +52,8 @@ func AgentDisplayName(name string) string {
 		return DisplayPiAgent
 	case AgentCodex:
 		return DisplayCodex
+	case AgentDevin:
+		return DisplayDevin
 	default:
 		return name
 	}

--- a/agent/devin/adapter.go
+++ b/agent/devin/adapter.go
@@ -1,0 +1,53 @@
+package devin
+
+import (
+	"context"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/safedep/gryph/config"
+	"github.com/safedep/gryph/core/events"
+)
+
+const (
+	AgentName   = agent.AgentDevin
+	DisplayName = agent.DisplayDevin
+)
+
+var _ agent.Adapter = (*Adapter)(nil)
+
+type Adapter struct {
+	privacyChecker *events.PrivacyChecker
+	loggingLevel   config.LoggingLevel
+	contentHash    bool
+}
+
+func New(privacyChecker *events.PrivacyChecker, loggingLevel config.LoggingLevel, contentHash bool) *Adapter {
+	return &Adapter{privacyChecker: privacyChecker, loggingLevel: loggingLevel, contentHash: contentHash}
+}
+
+func (a *Adapter) Name() string        { return AgentName }
+func (a *Adapter) DisplayName() string { return DisplayName }
+
+func (a *Adapter) Detect(ctx context.Context) (*agent.DetectionResult, error) {
+	return Detect(ctx)
+}
+
+func (a *Adapter) Install(ctx context.Context, opts agent.InstallOptions) (*agent.InstallResult, error) {
+	return InstallHooks(ctx, opts)
+}
+
+func (a *Adapter) Uninstall(ctx context.Context, opts agent.UninstallOptions) (*agent.UninstallResult, error) {
+	return UninstallHooks(ctx, opts)
+}
+
+func (a *Adapter) Status(ctx context.Context) (*agent.HookStatus, error) {
+	return GetHookStatus(ctx)
+}
+
+func (a *Adapter) ParseEvent(ctx context.Context, hookType string, rawData []byte) (*events.Event, error) {
+	return a.parseHookEvent(hookType, rawData)
+}
+
+func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, loggingLevel config.LoggingLevel, contentHash bool) {
+	registry.Register(New(privacyChecker, loggingLevel, contentHash))
+}

--- a/agent/devin/detect.go
+++ b/agent/devin/detect.go
@@ -1,0 +1,63 @@
+package devin
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/safedep/gryph/agent"
+)
+
+func Detect(ctx context.Context) (*agent.DetectionResult, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return &agent.DetectionResult{
+			Installed: false,
+			Message:   "could not determine home directory",
+		}, nil
+	}
+
+	devinDir := filepath.Join(home, ".config", "devin")
+
+	if _, err := os.Stat(devinDir); os.IsNotExist(err) {
+		return &agent.DetectionResult{
+			Installed: false,
+			Message:   "Devin CLI not installed (~/.config/devin not found)",
+		}, nil
+	}
+
+	result := &agent.DetectionResult{
+		Installed:  true,
+		Path:       devinDir,
+		ConfigPath: devinDir,
+		HooksPath:  filepath.Join(devinDir, "config.json"),
+	}
+
+	result.Version = getVersion(ctx)
+
+	return result, nil
+}
+
+func getVersion(ctx context.Context) string {
+	cmdCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	output, err := exec.CommandContext(cmdCtx, "devin", "--version").Output()
+	if err != nil {
+		return "unknown"
+	}
+
+	version := strings.TrimSpace(string(output))
+	if parts := strings.Fields(version); len(parts) > 0 {
+		for _, part := range parts {
+			if len(part) > 0 && part[0] >= '0' && part[0] <= '9' {
+				return part
+			}
+		}
+	}
+
+	return version
+}

--- a/agent/devin/hooks.go
+++ b/agent/devin/hooks.go
@@ -1,0 +1,415 @@
+package devin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/safedep/gryph/agent/utils"
+)
+
+var HookTypes = []string{
+	"SessionStart",
+	"PreToolUse",
+	"PostToolUse",
+	"UserPromptSubmit",
+	"Stop",
+	"SessionEnd",
+}
+
+// HookMatcher mirrors the Devin CLI hooks config structure, which is the same
+// JSON format used by Claude Code and Codex.
+type HookMatcher struct {
+	Matcher string        `json:"matcher,omitempty"`
+	Hooks   []HookCommand `json:"hooks"`
+}
+
+type HookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+func hookMatcher(hookType string) string {
+	switch hookType {
+	case "PreToolUse", "PostToolUse":
+		return "*"
+	default:
+		return ""
+	}
+}
+
+func gryphHookCommand(hookType string) string {
+	return fmt.Sprintf("%s _hook devin %s", utils.GryphCommand(), hookType)
+}
+
+// readDevinConfig reads the full Devin config.json as a raw JSON map so we
+// can merge the hooks section without touching unrelated settings.
+// Returns os.ErrNotExist (unwrapped via errors.Is) if the file does not exist.
+func readDevinConfig(configFile string) (map[string]json.RawMessage, error) {
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("config.json is malformed: %w", err)
+	}
+
+	return raw, nil
+}
+
+// readHooksFromConfig extracts and parses the hooks section from the raw config map.
+func readHooksFromConfig(raw map[string]json.RawMessage) (map[string][]HookMatcher, error) {
+	hooksRaw, ok := raw["hooks"]
+	if !ok {
+		return make(map[string][]HookMatcher), nil
+	}
+
+	var hooks map[string][]HookMatcher
+	if err := json.Unmarshal(hooksRaw, &hooks); err != nil {
+		return nil, fmt.Errorf("hooks section is malformed: %w", err)
+	}
+
+	if hooks == nil {
+		hooks = make(map[string][]HookMatcher)
+	}
+
+	return hooks, nil
+}
+
+// writeHooksToConfig serialises the hooks map back into the raw config map.
+func writeHooksToConfig(raw map[string]json.RawMessage, hooks map[string][]HookMatcher) error {
+	data, err := json.Marshal(hooks)
+	if err != nil {
+		return fmt.Errorf("failed to marshal hooks: %w", err)
+	}
+	raw["hooks"] = json.RawMessage(data)
+	return nil
+}
+
+// writeDevinConfig persists the full config map to disk, preserving all
+// existing keys outside the hooks section.
+func writeDevinConfig(configFile string, raw map[string]json.RawMessage) error {
+	data, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	return os.WriteFile(configFile, data, 0600)
+}
+
+func generateGryphHooks() map[string][]HookMatcher {
+	hooks := make(map[string][]HookMatcher)
+	for _, hookType := range HookTypes {
+		hooks[hookType] = []HookMatcher{
+			{
+				Matcher: hookMatcher(hookType),
+				Hooks: []HookCommand{
+					{
+						Type:    "command",
+						Command: gryphHookCommand(hookType),
+						Timeout: 30,
+					},
+				},
+			},
+		}
+	}
+	return hooks
+}
+
+func hasGryphHooks(hooks map[string][]HookMatcher) bool {
+	for _, hookType := range HookTypes {
+		for _, m := range hooks[hookType] {
+			for _, h := range m.Hooks {
+				if utils.IsGryphCommand(h.Command) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func mergeGryphHooks(existing map[string][]HookMatcher) map[string][]HookMatcher {
+	gryph := generateGryphHooks()
+
+	for hookType, matchers := range gryph {
+		found := false
+		for _, m := range existing[hookType] {
+			for _, h := range m.Hooks {
+				if h.Command == matchers[0].Hooks[0].Command {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			existing[hookType] = append(existing[hookType], matchers...)
+		}
+	}
+
+	return existing
+}
+
+func InstallHooks(ctx context.Context, opts agent.InstallOptions) (*agent.InstallResult, error) {
+	result := &agent.InstallResult{
+		BackupPaths: make(map[string]string),
+	}
+
+	detection, err := Detect(ctx)
+	if err != nil {
+		result.Error = err
+		return result, err
+	}
+
+	if !detection.Installed {
+		result.Error = fmt.Errorf("devin not detected: %s", detection.Message)
+		return result, result.Error
+	}
+
+	configFile := detection.HooksPath
+
+	if !opts.DryRun {
+		if err := os.MkdirAll(detection.ConfigPath, 0700); err != nil {
+			result.Error = fmt.Errorf("failed to create config directory: %w", err)
+			return result, result.Error
+		}
+	}
+
+	raw, err := readDevinConfig(configFile)
+	if os.IsNotExist(err) {
+		raw = make(map[string]json.RawMessage)
+	} else if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("config.json is malformed, hooks section will be replaced: %v", err))
+		raw = make(map[string]json.RawMessage)
+	}
+
+	existingHooks, err := readHooksFromConfig(raw)
+	if err != nil {
+		result.Warnings = append(result.Warnings, "hooks section is malformed, will be replaced")
+		existingHooks = nil
+	}
+
+	if existingHooks != nil {
+		if !opts.Force && !opts.DryRun && hasGryphHooks(existingHooks) {
+			result.Warnings = append(result.Warnings, "gryph hooks already installed (use --force to overwrite)")
+			result.Success = true
+			return result, nil
+		}
+
+		if opts.Backup && !opts.DryRun {
+			var backupPath string
+			if opts.BackupDir != "" {
+				backupDir := filepath.Join(opts.BackupDir, "devin")
+				if err := os.MkdirAll(backupDir, 0700); err != nil {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("failed to create backup directory: %v", err))
+				} else {
+					backupPath = filepath.Join(backupDir, fmt.Sprintf("config.json.backup.%s", time.Now().Format("20060102150405")))
+				}
+			} else {
+				backupPath = fmt.Sprintf("%s.backup.%s", configFile, time.Now().Format("20060102150405"))
+			}
+			if backupPath != "" {
+				if data, err := os.ReadFile(configFile); err == nil {
+					if err := os.WriteFile(backupPath, data, 0600); err == nil {
+						result.BackupPaths["config.json"] = backupPath
+					} else {
+						result.Warnings = append(result.Warnings, fmt.Sprintf("failed to backup config.json: %v", err))
+					}
+				}
+			}
+		}
+	}
+
+	if opts.DryRun {
+		result.HooksInstalled = HookTypes
+		result.Success = true
+		return result, nil
+	}
+
+	var mergedHooks map[string][]HookMatcher
+	if existingHooks != nil && !opts.Force {
+		mergedHooks = mergeGryphHooks(existingHooks)
+	} else {
+		mergedHooks = generateGryphHooks()
+	}
+
+	if err := writeHooksToConfig(raw, mergedHooks); err != nil {
+		result.Error = err
+		return result, result.Error
+	}
+
+	if err := writeDevinConfig(configFile, raw); err != nil {
+		result.Error = fmt.Errorf("failed to write config.json: %w", err)
+		return result, result.Error
+	}
+
+	result.HooksInstalled = HookTypes
+
+	status, err := GetHookStatus(ctx)
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("verification failed: %v", err))
+	} else if !status.Valid {
+		result.Warnings = append(result.Warnings, "hooks installed but validation failed")
+		result.Warnings = append(result.Warnings, status.Issues...)
+	}
+
+	result.Success = true
+	return result, nil
+}
+
+func UninstallHooks(ctx context.Context, opts agent.UninstallOptions) (*agent.UninstallResult, error) {
+	result := &agent.UninstallResult{}
+
+	detection, err := Detect(ctx)
+	if err != nil {
+		result.Error = err
+		return result, err
+	}
+
+	if !detection.Installed {
+		result.Success = true
+		return result, nil
+	}
+
+	configFile := detection.HooksPath
+
+	raw, err := readDevinConfig(configFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			result.Success = true
+			return result, nil
+		}
+		result.Error = fmt.Errorf("failed to read config.json: %w", err)
+		return result, result.Error
+	}
+
+	hooks, err := readHooksFromConfig(raw)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to parse hooks section: %w", err)
+		return result, result.Error
+	}
+
+	if opts.DryRun {
+		result.HooksRemoved = HookTypes
+		result.Success = true
+		return result, nil
+	}
+
+	if opts.RestoreBackup && opts.BackupDir != "" {
+		pattern := filepath.Join(opts.BackupDir, "devin", "config.json.backup.*")
+		matches, _ := filepath.Glob(pattern)
+		if len(matches) > 0 {
+			backupPath := matches[len(matches)-1]
+			if backupData, err := os.ReadFile(backupPath); err == nil {
+				if err := os.WriteFile(configFile, backupData, 0600); err == nil {
+					result.BackupsRestored = true
+					result.HooksRemoved = HookTypes
+					result.Success = true
+					return result, nil
+				}
+			}
+		}
+	}
+
+	for hookType := range hooks {
+		filtered := []HookMatcher{}
+		for _, m := range hooks[hookType] {
+			filteredHooks := []HookCommand{}
+			for _, h := range m.Hooks {
+				if !utils.IsGryphCommand(h.Command) {
+					filteredHooks = append(filteredHooks, h)
+				}
+			}
+			if len(filteredHooks) > 0 {
+				m.Hooks = filteredHooks
+				filtered = append(filtered, m)
+			} else {
+				result.HooksRemoved = append(result.HooksRemoved, hookType)
+			}
+		}
+		hooks[hookType] = filtered
+	}
+
+	if err := writeHooksToConfig(raw, hooks); err != nil {
+		result.Error = err
+		return result, result.Error
+	}
+
+	if err := writeDevinConfig(configFile, raw); err != nil {
+		result.Error = fmt.Errorf("failed to write config.json: %w", err)
+		return result, result.Error
+	}
+
+	result.Success = true
+	return result, nil
+}
+
+func GetHookStatus(ctx context.Context) (*agent.HookStatus, error) {
+	status := &agent.HookStatus{}
+
+	detection, err := Detect(ctx)
+	if err != nil {
+		return status, err
+	}
+
+	if !detection.Installed {
+		return status, nil
+	}
+
+	raw, err := readDevinConfig(detection.HooksPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return status, nil
+		}
+		status.Issues = append(status.Issues, fmt.Sprintf("cannot read config.json: %v", err))
+		return status, nil
+	}
+
+	hooks, err := readHooksFromConfig(raw)
+	if err != nil {
+		status.Issues = append(status.Issues, "hooks section in config.json is malformed")
+		return status, nil
+	}
+
+	status.Valid = true
+
+	for _, hookType := range HookTypes {
+		expectedCmd := gryphHookCommand(hookType)
+		for _, m := range hooks[hookType] {
+			for _, h := range m.Hooks {
+				if h.Command == expectedCmd {
+					status.Installed = true
+					status.Hooks = append(status.Hooks, hookType)
+					break
+				}
+			}
+		}
+	}
+
+	if status.Installed {
+		for _, hookType := range HookTypes {
+			found := false
+			for _, h := range status.Hooks {
+				if h == hookType {
+					found = true
+					break
+				}
+			}
+			if !found {
+				status.Valid = false
+				status.Issues = append(status.Issues, fmt.Sprintf("%s: hook not configured", hookType))
+			}
+		}
+	}
+
+	return status, nil
+}

--- a/agent/devin/parser.go
+++ b/agent/devin/parser.go
@@ -1,0 +1,479 @@
+package devin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+	"github.com/safedep/gryph/agent/utils"
+	"github.com/safedep/gryph/config"
+	"github.com/safedep/gryph/core/events"
+)
+
+type HookInput struct {
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	Cwd            string `json:"cwd"`
+	HookEventName  string `json:"hook_event_name"`
+	Model          string `json:"model"`
+}
+
+type PreToolUseInput struct {
+	HookInput
+	TurnID    string                 `json:"turn_id"`
+	ToolName  string                 `json:"tool_name"`
+	ToolUseID string                 `json:"tool_use_id"`
+	ToolInput map[string]interface{} `json:"tool_input"`
+}
+
+type PostToolUseInput struct {
+	HookInput
+	TurnID       string                 `json:"turn_id"`
+	ToolName     string                 `json:"tool_name"`
+	ToolUseID    string                 `json:"tool_use_id"`
+	ToolInput    map[string]interface{} `json:"tool_input"`
+	ToolResponse json.RawMessage        `json:"tool_response"`
+}
+
+type SessionStartInput struct {
+	HookInput
+	Source string `json:"source"`
+}
+
+type UserPromptSubmitInput struct {
+	HookInput
+	TurnID string `json:"turn_id"`
+	Prompt string `json:"prompt"`
+}
+
+type StopInput struct {
+	HookInput
+	TurnID               string `json:"turn_id"`
+	StopHookActive       bool   `json:"stop_hook_active"`
+	LastAssistantMessage string `json:"last_assistant_message"`
+}
+
+type SessionEndInput struct {
+	HookInput
+	Reason string `json:"reason"`
+}
+
+var ToolNameMapping = map[string]events.ActionType{
+	"Read":         events.ActionFileRead,
+	"View":         events.ActionFileRead,
+	"Write":        events.ActionFileWrite,
+	"Edit":         events.ActionFileWrite,
+	"NotebookEdit": events.ActionFileWrite,
+	"Bash":         events.ActionCommandExec,
+	"Execute":      events.ActionCommandExec,
+	"WebSearch":    events.ActionToolUse,
+	"WebFetch":     events.ActionToolUse,
+	"Grep":         events.ActionFileRead,
+	"Glob":         events.ActionFileRead,
+	"LS":           events.ActionFileRead,
+	"Task":         events.ActionToolUse,
+	"TodoRead":     events.ActionToolUse,
+	"TodoWrite":    events.ActionToolUse,
+	"AskUser":      events.ActionToolUse,
+}
+
+func (a *Adapter) parseHookEvent(hookType string, rawData []byte) (*events.Event, error) {
+	var baseInput HookInput
+	if err := json.Unmarshal(rawData, &baseInput); err != nil {
+		return nil, fmt.Errorf("failed to parse hook input: %w", err)
+	}
+
+	eventName := hookType
+	if eventName == "" {
+		eventName = baseInput.HookEventName
+	}
+
+	sessionID := resolveSessionID(baseInput.SessionID)
+	agentSessionID := baseInput.SessionID
+
+	switch eventName {
+	case "SessionStart":
+		return parseSessionStart(sessionID, agentSessionID, baseInput, rawData)
+	case "PreToolUse":
+		return a.parsePreToolUse(sessionID, agentSessionID, rawData)
+	case "PostToolUse":
+		return a.parsePostToolUse(sessionID, agentSessionID, rawData)
+	case "UserPromptSubmit":
+		return parseUserPromptSubmit(sessionID, agentSessionID, rawData)
+	case "Stop":
+		return parseStop(sessionID, agentSessionID, rawData)
+	case "SessionEnd":
+		return parseSessionEnd(sessionID, agentSessionID, rawData)
+	default:
+		event := events.NewEvent(sessionID, AgentName, events.ActionUnknown)
+		event.AgentSessionID = agentSessionID
+		event.WorkingDirectory = baseInput.Cwd
+		event.TranscriptPath = baseInput.TranscriptPath
+		event.RawEvent = rawData
+		return event, nil
+	}
+}
+
+func resolveSessionID(rawSessionID string) uuid.UUID {
+	if envID := os.Getenv("DEVIN_SESSION_ID"); envID != "" {
+		rawSessionID = envID
+	}
+
+	if rawSessionID != "" {
+		if parsed, err := uuid.Parse(rawSessionID); err == nil {
+			return parsed
+		}
+		return uuid.NewSHA1(uuid.NameSpaceOID, []byte(rawSessionID))
+	}
+
+	return uuid.New()
+}
+
+func parseSessionStart(sessionID uuid.UUID, agentSessionID string, base HookInput, rawData []byte) (*events.Event, error) {
+	var input SessionStartInput
+	if err := json.Unmarshal(rawData, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse SessionStart input: %w", err)
+	}
+
+	event := events.NewEvent(sessionID, AgentName, events.ActionSessionStart)
+	event.AgentSessionID = agentSessionID
+	event.WorkingDirectory = input.Cwd
+	event.TranscriptPath = input.TranscriptPath
+	event.RawEvent = rawData
+
+	payload := events.SessionPayload{
+		Source: input.Source,
+		Model:  input.Model,
+	}
+
+	if err := event.SetPayload(payload); err != nil {
+		return nil, fmt.Errorf("failed to set payload: %w", err)
+	}
+
+	return event, nil
+}
+
+func (a *Adapter) parsePreToolUse(sessionID uuid.UUID, agentSessionID string, rawData []byte) (*events.Event, error) {
+	var input PreToolUseInput
+	if err := json.Unmarshal(rawData, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse PreToolUse input: %w", err)
+	}
+
+	actionType := getActionType(input.ToolName)
+	event := events.NewEvent(sessionID, AgentName, actionType)
+	event.AgentSessionID = agentSessionID
+	event.ToolName = input.ToolName
+	event.WorkingDirectory = input.Cwd
+	event.TranscriptPath = input.TranscriptPath
+	event.RawEvent = rawData
+
+	if err := a.buildToolPayload(event, actionType, input.ToolInput, nil); err != nil {
+		return nil, fmt.Errorf("failed to build payload: %w", err)
+	}
+
+	a.markSensitivePaths(event, actionType, input.ToolInput)
+
+	return event, nil
+}
+
+func (a *Adapter) parsePostToolUse(sessionID uuid.UUID, agentSessionID string, rawData []byte) (*events.Event, error) {
+	var input PostToolUseInput
+	if err := json.Unmarshal(rawData, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse PostToolUse input: %w", err)
+	}
+
+	actionType := getActionType(input.ToolName)
+	event := events.NewEvent(sessionID, AgentName, actionType)
+	event.AgentSessionID = agentSessionID
+	event.ToolName = input.ToolName
+	event.WorkingDirectory = input.Cwd
+	event.TranscriptPath = input.TranscriptPath
+	event.RawEvent = rawData
+	event.ResultStatus = events.ResultSuccess
+
+	var toolResponse interface{}
+	if len(input.ToolResponse) > 0 {
+		var responseStr string
+		if err := json.Unmarshal(input.ToolResponse, &responseStr); err == nil {
+			toolResponse = responseStr
+		} else {
+			var structured interface{}
+			if err := json.Unmarshal(input.ToolResponse, &structured); err == nil {
+				toolResponse = structured
+			}
+		}
+	}
+
+	if err := a.buildToolPayload(event, actionType, input.ToolInput, toolResponse); err != nil {
+		return nil, fmt.Errorf("failed to build payload: %w", err)
+	}
+
+	a.markSensitivePaths(event, actionType, input.ToolInput)
+
+	return event, nil
+}
+
+func parseUserPromptSubmit(sessionID uuid.UUID, agentSessionID string, rawData []byte) (*events.Event, error) {
+	var input UserPromptSubmitInput
+	if err := json.Unmarshal(rawData, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse UserPromptSubmit input: %w", err)
+	}
+
+	event := events.NewEvent(sessionID, AgentName, events.ActionToolUse)
+	event.AgentSessionID = agentSessionID
+	event.ToolName = "UserPromptSubmit"
+	event.WorkingDirectory = input.Cwd
+	event.TranscriptPath = input.TranscriptPath
+	event.RawEvent = rawData
+
+	payload := events.ToolUsePayload{
+		ToolName: "UserPromptSubmit",
+	}
+
+	promptInput := map[string]string{"prompt": input.Prompt}
+	if data, err := json.Marshal(promptInput); err == nil {
+		payload.Input = data
+	}
+
+	if err := event.SetPayload(payload); err != nil {
+		return nil, fmt.Errorf("failed to set payload: %w", err)
+	}
+
+	return event, nil
+}
+
+func parseStop(sessionID uuid.UUID, agentSessionID string, rawData []byte) (*events.Event, error) {
+	var input StopInput
+	if err := json.Unmarshal(rawData, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse Stop input: %w", err)
+	}
+
+	event := events.NewEvent(sessionID, AgentName, events.ActionSessionEnd)
+	event.AgentSessionID = agentSessionID
+	event.WorkingDirectory = input.Cwd
+	event.TranscriptPath = input.TranscriptPath
+	event.RawEvent = rawData
+
+	payload := events.SessionEndPayload{
+		Reason: input.LastAssistantMessage,
+	}
+
+	if err := event.SetPayload(payload); err != nil {
+		return nil, fmt.Errorf("failed to set payload: %w", err)
+	}
+
+	return event, nil
+}
+
+func parseSessionEnd(sessionID uuid.UUID, agentSessionID string, rawData []byte) (*events.Event, error) {
+	var input SessionEndInput
+	if err := json.Unmarshal(rawData, &input); err != nil {
+		return nil, fmt.Errorf("failed to parse SessionEnd input: %w", err)
+	}
+
+	event := events.NewEvent(sessionID, AgentName, events.ActionSessionEnd)
+	event.AgentSessionID = agentSessionID
+	event.WorkingDirectory = input.Cwd
+	event.TranscriptPath = input.TranscriptPath
+	event.RawEvent = rawData
+
+	payload := events.SessionEndPayload{
+		Reason: input.Reason,
+	}
+
+	if err := event.SetPayload(payload); err != nil {
+		return nil, fmt.Errorf("failed to set payload: %w", err)
+	}
+
+	return event, nil
+}
+
+func getActionType(toolName string) events.ActionType {
+	if at, ok := ToolNameMapping[toolName]; ok {
+		return at
+	}
+	return events.ActionToolUse
+}
+
+func (a *Adapter) buildToolPayload(event *events.Event, actionType events.ActionType, toolInput map[string]interface{}, toolResponse interface{}) error {
+	switch actionType {
+	case events.ActionFileRead:
+		payload := events.FileReadPayload{}
+		if path, ok := toolInput["file_path"].(string); ok {
+			payload.Path = path
+		} else if path, ok := toolInput["path"].(string); ok {
+			payload.Path = path
+		}
+		if pattern, ok := toolInput["pattern"].(string); ok {
+			payload.Pattern = pattern
+		}
+		return event.SetPayload(payload)
+
+	case events.ActionFileWrite:
+		payload := events.FileWritePayload{}
+		filePath := ""
+		if path, ok := toolInput["file_path"].(string); ok {
+			payload.Path = path
+			filePath = path
+		}
+
+		fullOldStr, _ := toolInput["old_string"].(string)
+		fullNewStr, _ := toolInput["new_string"].(string)
+		fullContent, _ := toolInput["content"].(string)
+
+		if a.contentHash {
+			if fullContent != "" {
+				payload.ContentHash = utils.HashContent(fullContent)
+			} else if fullOldStr != "" || fullNewStr != "" {
+				payload.ContentHash = utils.HashContent(fullOldStr + fullNewStr)
+			}
+		}
+
+		if fullOldStr != "" || fullNewStr != "" {
+			payload.LinesAdded, payload.LinesRemoved = utils.CountDiffLines(fullOldStr, fullNewStr)
+		} else if fullContent != "" {
+			payload.LinesAdded = utils.CountNewFileLines(fullContent)
+		}
+
+		if fullContent != "" {
+			payload.ContentPreview = truncateString(fullContent, 200)
+		}
+		if fullOldStr != "" {
+			payload.OldString = truncateString(fullOldStr, 200)
+		}
+		if fullNewStr != "" {
+			payload.NewString = truncateString(fullNewStr, 200)
+		}
+
+		if err := event.SetPayload(payload); err != nil {
+			return err
+		}
+
+		if a.loggingLevel.IsAtLeast(config.LoggingFull) {
+			if fullOldStr != "" || fullNewStr != "" {
+				event.DiffContent = utils.GenerateDiff(filePath, fullOldStr, fullNewStr)
+			} else if fullContent != "" {
+				event.DiffContent = utils.GenerateDiff(filePath, "", fullContent)
+			}
+		}
+		return nil
+
+	case events.ActionCommandExec:
+		payload := events.CommandExecPayload{}
+		if cmd, ok := toolInput["command"].(string); ok {
+			payload.Command = cmd
+		}
+		if responseStr, ok := toolResponse.(string); ok {
+			payload.Output = truncateString(responseStr, 500)
+		}
+		return event.SetPayload(payload)
+
+	default:
+		payload := events.ToolUsePayload{
+			ToolName: event.ToolName,
+		}
+		if input, err := json.Marshal(toolInput); err == nil {
+			payload.Input = input
+		}
+		if toolResponse != nil {
+			if resp, err := json.Marshal(toolResponse); err == nil {
+				payload.Output = resp
+			}
+		}
+		return event.SetPayload(payload)
+	}
+}
+
+func (a *Adapter) markSensitivePaths(event *events.Event, actionType events.ActionType, toolInput map[string]interface{}) {
+	if a.privacyChecker == nil {
+		return
+	}
+
+	switch actionType {
+	case events.ActionFileRead, events.ActionFileWrite:
+		if path, ok := toolInput["file_path"].(string); ok {
+			event.IsSensitive = a.privacyChecker.IsSensitivePath(path)
+		} else if path, ok := toolInput["path"].(string); ok {
+			event.IsSensitive = a.privacyChecker.IsSensitivePath(path)
+		}
+	case events.ActionCommandExec:
+		if cmd, ok := toolInput["command"].(string); ok {
+			event.IsSensitive = a.privacyChecker.IsSensitivePath(cmd)
+		}
+	}
+}
+
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// HookResponse, HookDecision, and related types mirror Codex/Claude Code exit-code
+// semantics: 0 = allow, 1 = non-blocking error, 2 = block.
+type HookResponse struct {
+	Decision HookDecision
+	Message  string
+}
+
+type HookDecision int
+
+const (
+	HookAllow HookDecision = iota
+	HookBlock
+	HookError
+)
+
+func (r *HookResponse) ExitCode() int {
+	switch r.Decision {
+	case HookBlock:
+		return 2
+	case HookError:
+		return 1
+	default:
+		return 0
+	}
+}
+
+type preToolUseOutput struct {
+	HookSpecificOutput preToolUseDecision `json:"hookSpecificOutput"`
+}
+
+type preToolUseDecision struct {
+	HookEventName            string `json:"hookEventName"`
+	PermissionDecision       string `json:"permissionDecision"`
+	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
+}
+
+func (r *HookResponse) JSON() []byte {
+	output := preToolUseOutput{
+		HookSpecificOutput: preToolUseDecision{
+			HookEventName: "PreToolUse",
+		},
+	}
+
+	switch r.Decision {
+	case HookBlock:
+		output.HookSpecificOutput.PermissionDecision = "deny"
+		output.HookSpecificOutput.PermissionDecisionReason = r.Message
+	default:
+		output.HookSpecificOutput.PermissionDecision = "allow"
+	}
+
+	data, _ := json.Marshal(output)
+	return data
+}
+
+func NewAllowResponse() *HookResponse {
+	return &HookResponse{Decision: HookAllow}
+}
+
+func NewBlockResponse(message string) *HookResponse {
+	return &HookResponse{Decision: HookBlock, Message: message}
+}
+
+func NewErrorResponse(message string) *HookResponse {
+	return &HookResponse{Decision: HookError, Message: message}
+}

--- a/agent/devin/parser_test.go
+++ b/agent/devin/parser_test.go
@@ -1,0 +1,192 @@
+package devin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/safedep/gryph/config"
+	"github.com/safedep/gryph/core/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "Failed to read fixture: %s", name)
+	return data
+}
+
+func testPrivacyChecker(t *testing.T) *events.PrivacyChecker {
+	t.Helper()
+	pc, err := events.NewPrivacyChecker(events.DefaultSensitivePatterns(), nil)
+	require.NoError(t, err)
+	return pc
+}
+
+func testAdapter(t *testing.T) *Adapter {
+	t.Helper()
+	return New(testPrivacyChecker(t), config.LoggingStandard, true)
+}
+
+func TestParseHookEvent_SessionStart(t *testing.T) {
+	ctx := context.Background()
+	data := loadFixture(t, "session_start.json")
+
+	event, err := testAdapter(t).ParseEvent(ctx, "SessionStart", data)
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	assert.Equal(t, events.ActionSessionStart, event.ActionType)
+	assert.Equal(t, AgentName, event.AgentName)
+	assert.Equal(t, "devin-session-abc", event.AgentSessionID)
+	assert.Equal(t, "/home/user/project", event.WorkingDirectory)
+
+	payload := events.SessionPayload{}
+	require.NoError(t, json.Unmarshal(event.Payload, &payload))
+	assert.Equal(t, "startup", payload.Source)
+	assert.Equal(t, "claude-sonnet-4-6", payload.Model)
+}
+
+func TestParseHookEvent_PreToolUse_Bash(t *testing.T) {
+	ctx := context.Background()
+	data := loadFixture(t, "pre_tool_use_bash.json")
+
+	event, err := testAdapter(t).ParseEvent(ctx, "PreToolUse", data)
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	assert.Equal(t, events.ActionCommandExec, event.ActionType)
+	assert.Equal(t, "Bash", event.ToolName)
+	assert.Equal(t, AgentName, event.AgentName)
+	assert.Equal(t, "/home/user/project", event.WorkingDirectory)
+
+	payload, err := event.GetCommandExecPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "npm install", payload.Command)
+}
+
+func TestParseHookEvent_PostToolUse_Bash(t *testing.T) {
+	ctx := context.Background()
+	data := loadFixture(t, "post_tool_use_bash.json")
+
+	event, err := testAdapter(t).ParseEvent(ctx, "PostToolUse", data)
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	assert.Equal(t, events.ActionCommandExec, event.ActionType)
+	assert.Equal(t, "Bash", event.ToolName)
+	assert.Equal(t, events.ResultSuccess, event.ResultStatus)
+
+	payload, err := event.GetCommandExecPayload()
+	require.NoError(t, err)
+	assert.Equal(t, "npm install", payload.Command)
+	assert.Contains(t, payload.Output, "added 150 packages")
+}
+
+func TestParseHookEvent_UserPromptSubmit(t *testing.T) {
+	ctx := context.Background()
+	data := loadFixture(t, "user_prompt_submit.json")
+
+	event, err := testAdapter(t).ParseEvent(ctx, "UserPromptSubmit", data)
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	assert.Equal(t, events.ActionToolUse, event.ActionType)
+	assert.Equal(t, "UserPromptSubmit", event.ToolName)
+
+	payload, err := event.GetToolUsePayload()
+	require.NoError(t, err)
+	assert.Equal(t, "UserPromptSubmit", payload.ToolName)
+}
+
+func TestParseHookEvent_Stop(t *testing.T) {
+	ctx := context.Background()
+	data := loadFixture(t, "stop.json")
+
+	event, err := testAdapter(t).ParseEvent(ctx, "Stop", data)
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	assert.Equal(t, events.ActionSessionEnd, event.ActionType)
+
+	payload := events.SessionEndPayload{}
+	require.NoError(t, json.Unmarshal(event.Payload, &payload))
+	assert.Equal(t, "All tests are now passing.", payload.Reason)
+}
+
+func TestParseHookEvent_SessionEnd(t *testing.T) {
+	ctx := context.Background()
+	data := loadFixture(t, "session_end.json")
+
+	event, err := testAdapter(t).ParseEvent(ctx, "SessionEnd", data)
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	assert.Equal(t, events.ActionSessionEnd, event.ActionType)
+	assert.Equal(t, AgentName, event.AgentName)
+	assert.Equal(t, "/home/user/project", event.WorkingDirectory)
+}
+
+func TestParseHookEvent_DeterministicSessionID(t *testing.T) {
+	ctx := context.Background()
+	adapter := testAdapter(t)
+
+	data1 := loadFixture(t, "pre_tool_use_bash.json")
+	data2 := loadFixture(t, "post_tool_use_bash.json")
+
+	event1, err := adapter.ParseEvent(ctx, "PreToolUse", data1)
+	require.NoError(t, err)
+
+	event2, err := adapter.ParseEvent(ctx, "PostToolUse", data2)
+	require.NoError(t, err)
+
+	assert.Equal(t, event1.SessionID, event2.SessionID)
+
+	expected := uuid.NewSHA1(uuid.NameSpaceOID, []byte("devin-session-abc"))
+	assert.Equal(t, expected, event1.SessionID)
+}
+
+func TestParseHookEvent_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	adapter := testAdapter(t)
+
+	_, err := adapter.ParseEvent(ctx, "SessionStart", []byte("not-json"))
+	assert.Error(t, err)
+}
+
+func TestHookResponse_Allow(t *testing.T) {
+	resp := NewAllowResponse()
+	data := resp.JSON()
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	hookOutput, ok := parsed["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "allow", hookOutput["permissionDecision"])
+}
+
+func TestHookResponse_Block(t *testing.T) {
+	resp := NewBlockResponse("dangerous command")
+	data := resp.JSON()
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	hookOutput, ok := parsed["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "deny", hookOutput["permissionDecision"])
+	assert.Equal(t, "dangerous command", hookOutput["permissionDecisionReason"])
+}
+
+func TestHookResponse_ExitCodes(t *testing.T) {
+	assert.Equal(t, 0, NewAllowResponse().ExitCode())
+	assert.Equal(t, 2, NewBlockResponse("reason").ExitCode())
+	assert.Equal(t, 1, NewErrorResponse("error").ExitCode())
+}

--- a/agent/devin/testdata/post_tool_use_bash.json
+++ b/agent/devin/testdata/post_tool_use_bash.json
@@ -1,0 +1,14 @@
+{
+  "session_id": "devin-session-abc",
+  "transcript_path": "/home/user/.config/devin/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PostToolUse",
+  "model": "claude-sonnet-4-6",
+  "turn_id": "turn-001",
+  "tool_name": "Bash",
+  "tool_use_id": "tool-001",
+  "tool_input": {
+    "command": "npm install"
+  },
+  "tool_response": "added 150 packages in 12s"
+}

--- a/agent/devin/testdata/pre_tool_use_bash.json
+++ b/agent/devin/testdata/pre_tool_use_bash.json
@@ -1,0 +1,13 @@
+{
+  "session_id": "devin-session-abc",
+  "transcript_path": "/home/user/.config/devin/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "model": "claude-sonnet-4-6",
+  "turn_id": "turn-001",
+  "tool_name": "Bash",
+  "tool_use_id": "tool-001",
+  "tool_input": {
+    "command": "npm install"
+  }
+}

--- a/agent/devin/testdata/session_end.json
+++ b/agent/devin/testdata/session_end.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "devin-session-abc",
+  "transcript_path": "/home/user/.config/devin/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "SessionEnd",
+  "model": "claude-sonnet-4-6"
+}

--- a/agent/devin/testdata/session_start.json
+++ b/agent/devin/testdata/session_start.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "devin-session-abc",
+  "transcript_path": "/home/user/.config/devin/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "SessionStart",
+  "model": "claude-sonnet-4-6",
+  "source": "startup"
+}

--- a/agent/devin/testdata/stop.json
+++ b/agent/devin/testdata/stop.json
@@ -1,0 +1,10 @@
+{
+  "session_id": "devin-session-abc",
+  "transcript_path": "/home/user/.config/devin/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "Stop",
+  "model": "claude-sonnet-4-6",
+  "turn_id": "turn-003",
+  "stop_hook_active": true,
+  "last_assistant_message": "All tests are now passing."
+}

--- a/agent/devin/testdata/user_prompt_submit.json
+++ b/agent/devin/testdata/user_prompt_submit.json
@@ -1,0 +1,9 @@
+{
+  "session_id": "devin-session-abc",
+  "transcript_path": "/home/user/.config/devin/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "UserPromptSubmit",
+  "model": "claude-sonnet-4-6",
+  "turn_id": "turn-002",
+  "prompt": "Fix the failing test in main_test.go"
+}

--- a/agent/registry.go
+++ b/agent/registry.go
@@ -82,6 +82,7 @@ func SupportedAgents() []string {
 		"claude-code",
 		"codex",
 		"cursor",
+		"devin",
 		"gemini",
 		"opencode",
 		"openclaw",

--- a/cli/hook.go
+++ b/cli/hook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/safedep/gryph/agent/claudecode"
 	"github.com/safedep/gryph/agent/codex"
 	"github.com/safedep/gryph/agent/cursor"
+	"github.com/safedep/gryph/agent/devin"
 	"github.com/safedep/gryph/agent/gemini"
 	"github.com/safedep/gryph/agent/openclaw"
 	"github.com/safedep/gryph/agent/opencode"
@@ -295,6 +296,11 @@ func sendHookResponse(agentName, hookType string) error {
 		// support the "allow" permissionDecision value).
 		return nil
 
+	case agent.AgentDevin:
+		// Devin CLI: same hook semantics as Codex (exit 0 = allow, exit 2 = block).
+		// PreToolUse supports deny via JSON on stdout or exit code 2.
+		return nil
+
 	default:
 		// Unknown agent, just succeed
 		return nil
@@ -364,6 +370,15 @@ func sendSecurityBlockedResponse(agentName, hookType string, result *security.Re
 			}
 		}
 		return handleCodexResponse(response)
+
+	case agent.AgentDevin:
+		response := devin.NewBlockResponse(result.BlockReason)
+		if hookType == "PreToolUse" {
+			if _, err := os.Stdout.Write(response.JSON()); err != nil {
+				log.Errorf("failed to write to stdout: %v", err)
+			}
+		}
+		return handleDevinResponse(response)
 
 	default:
 		return nil
@@ -488,6 +503,18 @@ func handleCodexResponse(response *codex.HookResponse) error {
 	case codex.HookBlock:
 		return &exitError{code: 2, message: response.Message}
 	case codex.HookError:
+		return &exitError{code: 1, message: response.Message}
+	default:
+		return nil
+	}
+}
+
+// handleDevinResponse processes a Devin CLI hook response.
+func handleDevinResponse(response *devin.HookResponse) error {
+	switch response.Decision {
+	case devin.HookBlock:
+		return &exitError{code: 2, message: response.Message}
+	case devin.HookError:
 		return &exitError{code: 1, message: response.Message}
 	default:
 		return nil

--- a/cli/root.go
+++ b/cli/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/safedep/gryph/agent/claudecode"
 	"github.com/safedep/gryph/agent/codex"
 	"github.com/safedep/gryph/agent/cursor"
+	"github.com/safedep/gryph/agent/devin"
 	"github.com/safedep/gryph/agent/gemini"
 	"github.com/safedep/gryph/agent/opencode"
 	"github.com/safedep/gryph/agent/piagent"
@@ -59,6 +60,7 @@ func NewApp(cfg *config.Config) (*App, error) {
 	windsurf.Register(registry, privacyChecker, cfg.GetAgentLoggingLevel(agent.AgentWindsurf), cfg.Logging.ContentHash)
 	piagent.Register(registry, privacyChecker, cfg.GetAgentLoggingLevel(agent.AgentPiAgent), cfg.Logging.ContentHash)
 	codex.Register(registry, privacyChecker, cfg.GetAgentLoggingLevel(agent.AgentCodex), cfg.Logging.ContentHash)
+	devin.Register(registry, privacyChecker, cfg.GetAgentLoggingLevel(agent.AgentDevin), cfg.Logging.ContentHash)
 
 	// For now, let us keep openclaw agent disabled because it is non-functional
 	// openclaw.Register(registry, privacyChecker, cfg.GetAgentLoggingLevel(agent.AgentOpenClaw), cfg.Logging.ContentHash)

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ const (
 	agentNameWindsurf   = "windsurf"
 	agentNamePiAgent    = "pi-agent"
 	agentNameCodex      = "codex"
+	agentNameDevin      = "devin"
 
 	streamTargetTypeStdout = "stdout"
 	streamTargetTypeNop    = "nop"
@@ -126,6 +127,7 @@ type AgentsConfig struct {
 	Windsurf   AgentConfig `mapstructure:"windsurf"`
 	PiAgent    AgentConfig `mapstructure:"pi-agent"`
 	Codex      AgentConfig `mapstructure:"codex"`
+	Devin      AgentConfig `mapstructure:"devin"`
 }
 
 // DisplayConfig holds display-related settings.
@@ -290,6 +292,10 @@ func (c *Config) GetAgentLoggingLevel(agentName string) LoggingLevel {
 		if c.Agents.Codex.LoggingLevel != "" {
 			return c.Agents.Codex.LoggingLevel
 		}
+	case agentNameDevin:
+		if c.Agents.Devin.LoggingLevel != "" {
+			return c.Agents.Devin.LoggingLevel
+		}
 	}
 
 	return c.Logging.Level
@@ -314,6 +320,8 @@ func (c *Config) IsAgentEnabled(agentName string) bool {
 		return c.Agents.PiAgent.Enabled
 	case agentNameCodex:
 		return c.Agents.Codex.Enabled
+	case agentNameDevin:
+		return c.Agents.Devin.Enabled
 	default:
 		return true
 	}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -33,6 +33,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("agents.windsurf.enabled", true)
 	v.SetDefault("agents.pi-agent.enabled", true)
 	v.SetDefault("agents.codex.enabled", true)
+	v.SetDefault("agents.devin.enabled", true)
 
 	// Display defaults
 	v.SetDefault("display.colors", "auto")

--- a/config/validate.go
+++ b/config/validate.go
@@ -75,6 +75,9 @@ func validate(cfg *Config) error {
 	if cfg.Agents.Codex.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.Codex.LoggingLevel) {
 		return fmt.Errorf("invalid agents.codex.logging_level: %s", cfg.Agents.Codex.LoggingLevel)
 	}
+	if cfg.Agents.Devin.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.Devin.LoggingLevel) {
+		return fmt.Errorf("invalid agents.devin.logging_level: %s", cfg.Agents.Devin.LoggingLevel)
+	}
 
 	return nil
 }

--- a/test/cli/e2e_hook_test.go
+++ b/test/cli/e2e_hook_test.go
@@ -886,3 +886,98 @@ func TestHook_Codex_DeterministicSessionID(t *testing.T) {
 
 	assert.Equal(t, evts[0].SessionID, evts[1].SessionID, "same session_id should produce same UUID")
 }
+
+func TestHook_Devin(t *testing.T) {
+	tests := []struct {
+		name       string
+		hookType   string
+		fixture    string
+		actionType events.ActionType
+	}{
+		{
+			name:       "PreToolUse_Bash",
+			hookType:   "PreToolUse",
+			fixture:    "pre_tool_use_bash.json",
+			actionType: events.ActionCommandExec,
+		},
+		{
+			name:       "PostToolUse_Bash",
+			hookType:   "PostToolUse",
+			fixture:    "post_tool_use_bash.json",
+			actionType: events.ActionCommandExec,
+		},
+		{
+			name:       "SessionStart",
+			hookType:   "SessionStart",
+			fixture:    "session_start.json",
+			actionType: events.ActionSessionStart,
+		},
+		{
+			name:       "UserPromptSubmit",
+			hookType:   "UserPromptSubmit",
+			fixture:    "user_prompt_submit.json",
+			actionType: events.ActionToolUse,
+		},
+		{
+			name:       "Stop",
+			hookType:   "Stop",
+			fixture:    "stop.json",
+			actionType: events.ActionSessionEnd,
+		},
+		{
+			name:       "SessionEnd",
+			hookType:   "SessionEnd",
+			fixture:    "session_end.json",
+			actionType: events.ActionSessionEnd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newTestEnv(t)
+			ctx := context.Background()
+
+			payload, err := os.ReadFile("../../agent/devin/testdata/" + tt.fixture)
+			require.NoError(t, err)
+
+			_, _, runErr := env.runHook("devin", tt.hookType, payload)
+			require.NoError(t, runErr)
+
+			store, cleanup := env.openStore()
+			defer cleanup()
+
+			evts, err := store.QueryEvents(ctx, events.NewEventFilter())
+			require.NoError(t, err)
+			require.Len(t, evts, 1)
+
+			assert.Equal(t, tt.actionType, evts[0].ActionType)
+			assert.Equal(t, "devin", evts[0].AgentName)
+		})
+	}
+}
+
+func TestHook_Devin_DeterministicSessionID(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := context.Background()
+
+	payload1, err := os.ReadFile("../../agent/devin/testdata/pre_tool_use_bash.json")
+	require.NoError(t, err)
+
+	payload2, err := os.ReadFile("../../agent/devin/testdata/post_tool_use_bash.json")
+	require.NoError(t, err)
+
+	_, _, err = env.runHook("devin", "PreToolUse", payload1)
+	require.NoError(t, err)
+
+	_, _, err = env.runHook("devin", "PostToolUse", payload2)
+	require.NoError(t, err)
+
+	store, cleanup := env.openStore()
+	defer cleanup()
+
+	evts, err := store.QueryEvents(ctx, events.NewEventFilter())
+	require.NoError(t, err)
+	require.Len(t, evts, 2)
+
+	assert.Equal(t, evts[0].SessionID, evts[1].SessionID, "same session_id should produce same UUID")
+}

--- a/tui/component/livelog/model.go
+++ b/tui/component/livelog/model.go
@@ -8,7 +8,7 @@ import (
 	"github.com/safedep/gryph/core/events"
 )
 
-var agentCycle = []string{"", "claude-code", "codex", "cursor", "gemini", "opencode", "openclaw", "windsurf", "pi-agent"}
+var agentCycle = []string{"", "claude-code", "codex", "cursor", "devin", "gemini", "opencode", "openclaw", "windsurf", "pi-agent"}
 
 type Model struct {
 	opts   Options

--- a/tui/component/livelog/styles.go
+++ b/tui/component/livelog/styles.go
@@ -120,6 +120,8 @@ func agentBadge(agentName string) string {
 		return lipgloss.NewStyle().Foreground(colorOrange).Bold(true).Render("claude-code")
 	case "codex":
 		return lipgloss.NewStyle().Foreground(colorYellow).Bold(true).Render("codex")
+	case "devin":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#00B4D8")).Bold(true).Render("devin")
 	case "cursor":
 		return lipgloss.NewStyle().Foreground(colorViolet).Bold(true).Render("cursor")
 	case "gemini":


### PR DESCRIPTION
## Summary

Adds full support for [Devin CLI](https://cli.devin.ai) as a gryph-monitored agent.

- Devin CLI uses the same Claude Code-compatible hook protocol as Codex (same JSON field names, same event types, same exit-code semantics for blocking)
- The adapter is an independent copy rather than a delegation to the Codex adapter, so the two can diverge safely as each CLI evolves
- Hook installation merges into `~/.config/devin/config.json` (Devin's single config file), preserving all other settings — unlike Codex which owns a dedicated `hooks.json`
- Adds explicit `SessionEnd` event handling (Devin fires this; mapped to `ActionSessionEnd`)
- Session IDs resolved via `DEVIN_SESSION_ID` env var or deterministic SHA1 of the raw `session_id` field

## Changes

| Area | Change |
|---|---|
| `agent/devin/` | New adapter package: adapter, detect, hooks, parser, tests, testdata |
| `agent/{adapter,registry}.go` | `AgentDevin` / `DisplayDevin` constants |
| `config/{config,defaults,validate}.go` | Per-agent config fields and validation |
| `cli/{root,hook}.go` | Register adapter; wire allow/block hook responses |
| `tui/component/livelog/` | Devin badge (cyan `#00B4D8`) in agent cycle |
| `test/cli/e2e_hook_test.go` | E2E tests for all 6 hook types + deterministic session ID |

## Test plan

- [ ] `go test ./agent/devin/...` — unit tests for all event types, HookResponse encoding, deterministic session IDs
- [ ] `go test ./test/cli/... -run TestHook_Devin` — e2e hook tests for all 6 event types
- [ ] `gryph install` on a machine with Devin CLI installed — verify hooks appear in `~/.config/devin/config.json` without disturbing other settings
- [ ] `gryph status` — shows Devin CLI hooks as installed/valid
- [ ] `gryph uninstall` — removes only gryph hooks, preserves rest of config

## Related

Closes the gap for users who run Devin CLI alongside Claude Code or Codex and want a unified audit trail across all agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)