### PR TITLE
fix: redact and level-gate SubagentStop and SessionEnd payloads

### DIFF
--- a/agent/filter.go
+++ b/agent/filter.go
@@ -65,5 +65,15 @@ func stripPayloadContent(event *events.Event) {
 			p.Output = nil
 			p.OutputPreview = ""
 		})
+
+	case events.ActionSubagentStop:
+		mutatePayload(event, func(p *events.SubagentStopPayload) {
+			p.LastAssistantMessage = ""
+		})
+
+	case events.ActionSessionEnd:
+		mutatePayload(event, func(p *events.SessionEndPayload) {
+			p.Reason = ""
+		})
 	}
 }

--- a/agent/filter_test.go
+++ b/agent/filter_test.go
@@ -207,3 +207,31 @@ func TestApplyLoggingLevel_Minimal_FileRead(t *testing.T) {
 	assert.Nil(t, event.RawEvent)
 	assert.Equal(t, json.RawMessage(originalPayload), event.Payload)
 }
+
+func TestApplyLoggingLevel_MinimalStripsSubagentStopMessage(t *testing.T) {
+	event := events.NewEvent(uuid.New(), "test-agent", events.ActionSubagentStop)
+	require.NoError(t, event.SetPayload(events.SubagentStopPayload{
+		AgentID:              "agent-1",
+		LastAssistantMessage: "secret summary of the repo",
+	}))
+
+	ApplyLoggingLevel(event, config.LoggingMinimal)
+
+	var p events.SubagentStopPayload
+	require.NoError(t, json.Unmarshal(event.Payload, &p))
+	assert.Empty(t, p.LastAssistantMessage)
+	assert.Equal(t, "agent-1", p.AgentID)
+}
+
+func TestApplyLoggingLevel_MinimalStripsSessionEndReason(t *testing.T) {
+	event := events.NewEvent(uuid.New(), "test-agent", events.ActionSessionEnd)
+	require.NoError(t, event.SetPayload(events.SessionEndPayload{
+		Reason: "secret summary of the repo",
+	}))
+
+	ApplyLoggingLevel(event, config.LoggingMinimal)
+
+	var p events.SessionEndPayload
+	require.NoError(t, json.Unmarshal(event.Payload, &p))
+	assert.Empty(t, p.Reason)
+}

--- a/agent/redact.go
+++ b/agent/redact.go
@@ -46,5 +46,15 @@ func RedactEvent(event *events.Event, checker *events.PrivacyChecker) {
 			p.Output = checker.RedactJSON(p.Output)
 			p.OutputPreview = checker.Redact(p.OutputPreview)
 		})
+
+	case events.ActionSubagentStop:
+		mutatePayload(event, func(p *events.SubagentStopPayload) {
+			p.LastAssistantMessage = checker.Redact(p.LastAssistantMessage)
+		})
+
+	case events.ActionSessionEnd:
+		mutatePayload(event, func(p *events.SessionEndPayload) {
+			p.Reason = checker.Redact(p.Reason)
+		})
 	}
 }

--- a/agent/redact_test.go
+++ b/agent/redact_test.go
@@ -124,3 +124,38 @@ func TestRedactEvent_NilChecker(t *testing.T) {
 
 	assert.Equal(t, "password=hunter2", event.DiffContent)
 }
+
+func TestRedactEvent_SubagentStop(t *testing.T) {
+	checker, err := events.NewPrivacyChecker(nil, events.DefaultRedactPatterns())
+	require.NoError(t, err)
+
+	event := events.NewEvent(uuid.New(), "test-agent", events.ActionSubagentStop)
+	require.NoError(t, event.SetPayload(events.SubagentStopPayload{
+		AgentID:              "agent-1",
+		AgentType:            "explore",
+		LastAssistantMessage: "the deploy key is password=hunter2",
+	}))
+
+	RedactEvent(event, checker)
+
+	var p events.SubagentStopPayload
+	require.NoError(t, json.Unmarshal(event.Payload, &p))
+	assert.NotContains(t, p.LastAssistantMessage, "hunter2")
+	assert.Equal(t, "agent-1", p.AgentID)
+}
+
+func TestRedactEvent_SessionEnd(t *testing.T) {
+	checker, err := events.NewPrivacyChecker(nil, events.DefaultRedactPatterns())
+	require.NoError(t, err)
+
+	event := events.NewEvent(uuid.New(), "test-agent", events.ActionSessionEnd)
+	require.NoError(t, event.SetPayload(events.SessionEndPayload{
+		Reason: "wrapped up, token=xyz789 was rotated",
+	}))
+
+	RedactEvent(event, checker)
+
+	var p events.SessionEndPayload
+	require.NoError(t, json.Unmarshal(event.Payload, &p))
+	assert.NotContains(t, p.Reason, "xyz789")
+}


### PR DESCRIPTION
Fixes #46.

`stripPayloadContent` and `RedactEvent` enumerate only `ActionFileWrite`, `ActionCommandExec` and `ActionToolUse`. Two content-bearing payloads ride other action types and were therefore never scrubbed:

- `SubagentStopPayload.LastAssistantMessage` on `ActionSubagentStop`
- `SessionEndPayload.Reason` on `ActionSessionEnd`

`IsSensitive` is only set from file-path or command matches, so the unconditional strip in `ApplyLoggingLevel` never covered these either. The result is the agent's final assistant message stored verbatim at every logging level including `minimal`, with configured `redact_patterns` not applied.

This adds cases for both action types to both switches, scrubbing the message and reason fields and leaving `agent_id` and `agent_type` intact so the events stay useful for tracing.

Four tests added, two per file. They fail on `main`:

```
--- FAIL: TestApplyLoggingLevel_MinimalStripsSubagentStopMessage
--- FAIL: TestApplyLoggingLevel_MinimalStripsSessionEndReason
--- FAIL: TestRedactEvent_SubagentStop
--- FAIL: TestRedactEvent_SessionEnd
```

and pass with the change. `go build ./...` and `go test ./agent/...` are green.

Two follow-ups I did not fold in here, happy to do either if you want them:

- Invert the design so payload text is scrubbed by default and safe fields are enumerated, so a newly added event type fails closed instead of leaking.
- The codex parser stores the untruncated last assistant message where the claudecode parser truncates to 500 chars.
