### PR TITLE
Add policy authoring commands: list, install, and multi-file support

### DIFF
--- a/.claude/skills/aarm-policy-layer/SKILL.md
+++ b/.claude/skills/aarm-policy-layer/SKILL.md
@@ -22,7 +22,7 @@ Three invariants break silently if you miss them. The doc explains all three.
 
 1. The receipt and context hashes are consensus formats. A change to field order or canonicalization breaks every existing chain. Update the verifier and the property tests in the same change.
 2. The `aarm` package stays decoupled from `storage` and `cli`. Carry CLI-shaped side effects through the hooks (`DeferralHook`, `ApprovalAuditHook`, `IdentityAuditHook`). Do not add a `storage` or `cli` import to `aarm`.
-3. Policy resolution is additive and same-user safe. `disabled:` is scoped to the file that declares the rule, block always beats allow, and no user file can disable a built-in. Keep these when you touch `Loader.Load` or the merge, so an installed policy file can never weaken the built-in floor or another file's rules. See `docs/security-policy-threat-model.md`.
+3. Policy resolution is additive and same-user safe. `disabled:` is scoped to the file that declares the rule, block always beats allow, and no user file can disable a built-in. Keep these when you touch `Loader.Load` or the merge, so an installed policy file can never remove the built-in rules or another file's rules. See `docs/security-policy-threat-model.md`.
 
 ## Keep the doc correct
 

--- a/.claude/skills/aarm-policy-layer/SKILL.md
+++ b/.claude/skills/aarm-policy-layer/SKILL.md
@@ -18,10 +18,11 @@ Do not change the AARM layer from memory. The layer spans about 15 packages unde
 
 ## Load-bearing invariants
 
-Two invariants break silently if you miss them. The doc explains both.
+Three invariants break silently if you miss them. The doc explains all three.
 
 1. The receipt and context hashes are consensus formats. A change to field order or canonicalization breaks every existing chain. Update the verifier and the property tests in the same change.
 2. The `aarm` package stays decoupled from `storage` and `cli`. Carry CLI-shaped side effects through the hooks (`DeferralHook`, `ApprovalAuditHook`, `IdentityAuditHook`). Do not add a `storage` or `cli` import to `aarm`.
+3. Policy resolution is additive and same-user safe. `disabled:` is scoped to the file that declares the rule, block always beats allow, and no user file can disable a built-in. Keep these when you touch `Loader.Load` or the merge, so an installed policy file can never weaken the built-in floor or another file's rules. See `docs/security-policy-threat-model.md`.
 
 ## Keep the doc correct
 

--- a/.claude/skills/aarm-policy-layer/SKILL.md
+++ b/.claude/skills/aarm-policy-layer/SKILL.md
@@ -27,3 +27,15 @@ Three invariants break silently if you miss them. The doc explains all three.
 ## Keep the doc correct
 
 The doc is the source of truth, so keep it accurate. If you find the code no longer matches the doc, update `docs/aarm-dev.md` in the same change. Do not fork the guidance into this skill.
+
+## Keep the user-facing policy doc fresh
+
+`docs/security-policy.md` is the user-facing guide for policy authors. Whenever you make a UX-related change in the policy layer, update it in the same change. UX-related changes include:
+
+- New, renamed, or removed `gryph policy ...` commands or flags (init, edit, list, install, validate, test, receipts, context, deferrals, approve, keys).
+- Changes to the policy YAML surface: rule fields, match criteria, CEL variables, decisions, or the `disabled:` mechanism.
+- Changes to configuration keys under `policy:` in the config file, or to their defaults.
+- Changes to default behavior a user can observe: sign modes, fail modes, retention, auto-defer triggers, approval prompts, block or guidance message format.
+- Changes to file locations the user interacts with: `policy.yaml`, the `policies/` directory, the keys directory, the trust store.
+
+Keep `docs/aarm-dev.md` for internals and `docs/security-policy.md` for the user surface. A change that touches both layers updates both docs.

--- a/.claude/skills/aarm-policy-layer/SKILL.md
+++ b/.claude/skills/aarm-policy-layer/SKILL.md
@@ -16,7 +16,7 @@ Do not change the AARM layer from memory. The layer spans about 15 packages unde
 3. Add a Mediator dependency through a `MediatorOption` in `aarm/check.go`, then wire it in `loadPolicyMediator` in `cli/policy.go`.
 4. Run `make test` and `make lint` before you finish. Run `make generate-schema` after any change to the policy schema or a payload type.
 
-## Load-bearing invariants
+## Invariants
 
 Three invariants break silently if you miss them. The doc explains all three.
 

--- a/.claude/skills/gryph-policy-authoring/SKILL.md
+++ b/.claude/skills/gryph-policy-authoring/SKILL.md
@@ -1,105 +1,110 @@
 ---
 name: gryph-policy-authoring
-description: Use when a user wants to author, edit, install, or test a Gryph security policy that governs what an AI coding agent may do. Trigger whenever the user wants Gryph to block, allow, warn on, or require approval for an agent action, wants to write or change a rule in a policy file, asks how to match a tool, command, file path, or URL, works with CEL conditions or context counters in a rule, wants to split policy into many files, or wants to dry-run and verify a policy with `gryph policy test`. Also trigger on phrases like "write a gryph policy", "add a policy rule", "make gryph block X", "test my policy", "install a policy", or "policy for my agent", even when the user does not name a file. This skill is for authoring and testing policy content, not for changing the policy engine code (use aarm-policy-layer for engine work under aarm/ or cli/policy.go).
+description: Use when a human wants help to author or change a Gryph security policy that governs what an AI coding agent may do, often with an agent's help. Trigger whenever the user wants Gryph to block, allow, warn on, or require approval for an agent action, wants to write or change a policy rule, asks how to match a tool, command, file path, or URL, works with CEL conditions or context counters, wants to split policy into many files, or wants to dry-run a rule. Also trigger on phrases like "write a gryph policy", "add a policy rule", "make gryph block X", "help me write a policy", or "policy for my agent", even when the user does not name a file. This skill drafts a policy in a workspace directory and hands the user an install command. It never installs the policy and never writes into Gryph's config directory. It is not for changing the policy engine code (use aarm-policy-layer for engine work under aarm/ or cli/policy.go).
 ---
 
-# Authoring and Testing Gryph Policies
+# Authoring Gryph Policies
 
 Gryph mediates what an AI coding agent reads, writes, and runs. A policy is an ordered
 list of rules. Each rule matches an action and returns a decision. This skill helps a
-user author those rules and test them before they go live.
+human draft those rules, with an agent's help, then hands the human a command to install
+them.
 
-Gryph resolves user policy from two places, both in Gryph's config directory: the global
-`policy.yaml`, and every `*.yaml` file in the `policies/` directory. Gryph merges its own
-built-in self-protection rules last. So the effective policy is your files plus the
-built-ins. Keep one global file, or split rules into many small files in `policies/`, one
-concern per file. Rule IDs must be unique across every file. Per-project policy is not
-wired today.
+You draft in a workspace directory. You never install. You never write into Gryph's
+config directory. The human reviews the draft and runs the install command you give at
+the end. This keeps the human in control of what becomes active policy.
 
-Two sources of truth back this work. Use both. Do not author rules from memory.
+## The two hard rules
 
-- `docs/security-policy.md` in this repo is the full author guide. It explains match
-  criteria, scope, CEL conditions, decisions, messages, receipts, deferrals, approval,
-  risk signals, and has worked examples. Read the section you need before you write a
-  rule.
-- The installed `gryph` binary is the authoritative, version-matched surface. Drive it
-  for the exact schema and for testing. The doc explains the concepts, the binary
-  confirms the fields.
+1. Draft only in a workspace directory you create, for example `./gryph-policy/`. Never
+   write a policy file into Gryph's config directory or its `policies/` directory. Gryph
+   blocks an agent write there by design, and a direct write bypasses the human review.
+2. Never install. Do not run `gryph policy install`, `gryph policy edit`, or
+   `gryph policy init <name>` (a bare name writes into `policies/`). These change live
+   policy. Your job ends at a validated draft plus an install command for the human.
 
-## The authoring loop
+## The gryph binary is the source of truth
 
-Follow this loop. Each step feeds the next.
+The installed `gryph` binary is authoritative and version-matched. Read the schema and
+the existing policy from it. Do not author fields from memory.
 
-1. Open a policy file. Run `gryph policy list` first to see every active source and its
-   rule count. To edit the global file, run `gryph policy edit`. To author a separate
-   file for one concern, run `gryph policy edit <name>`, which opens
-   `policies/<name>.yaml` and scaffolds it from the commented example when it is missing.
-   Run `gryph policy init` (or `gryph policy init <name>`) to scaffold the example
-   without opening an editor. Never run `gryph policy init --force` on an existing file
-   without explicit confirmation, because it overwrites the user's rules with the
-   example. `gryph policy validate` prints the resolved paths.
+- `gryph policy schema` prints the exact rule fields, match criteria, and decision set.
+  This is the single source of truth for the schema. Check it before you write a field.
+- `gryph policy builtin` prints Gryph's own built-in rules. Read them as working examples
+  to imitate, and to see what already fires so your rule does not collide with them.
+- `gryph policy list` shows every active source and its rule count.
 
-2. Learn the surface from the binary, not from guesswork. Run `gryph policy schema` for
-   the authoritative rule fields, match criteria, and the decision set. Run
-   `gryph policy builtin` to read Gryph's own built-in rules as working, real-world
-   examples to imitate. If you are unsure a field exists or a decision is spelled right,
-   check `schema` before you write it.
+`docs/security-policy.md` in this repo is a concept guide. It explains match criteria,
+scope, CEL conditions, decisions, messages, receipts, and has worked examples. Read the
+section you need for concepts. When the doc and the binary disagree, trust the binary and
+tell the user.
 
-3. Author the rule. Match on `action_types`, tools, file patterns, commands, or URLs,
-   then narrow with a CEL `condition` when the match criteria are not enough. Read the
-   "Authoring a rule", "Match criteria", and "Conditions (CEL)" sections of
-   `docs/security-policy.md` for the field details.
+You may read the active policy for context: read the resolved `policy.yaml` (its path is
+printed by `gryph policy validate`) and the files in `policies/`. Read only. Never write
+there.
 
-4. Validate. Run `gryph policy validate`. It compiles the merged policy and reports the
-   rule count. Fix every error before you test. `gryph policy edit` runs this for you on
-   save when the target is the global file or a named file.
+## The authoring workflow
 
-5. Test with synthetic actions. This is the core of getting a rule right. See the
-   testing section below.
+1. Make a workspace directory and work inside it.
 
-6. Iterate. Adjust the rule and repeat from step 4 until the decisions match intent.
+   ```bash
+   mkdir -p gryph-policy
+   ```
 
-## Authoring as an agent: the review gate
+   This directory is a draft area. Gryph never resolves it. Name each draft file for its
+   purpose, for example `gryph-policy/no-prod-writes.yaml`. Namespace the rule IDs the
+   same way, because IDs must be unique across every file once installed.
 
-An agent cannot write into the config directory. The built-in self-protection rules
-block an agent `file_write` into `policy.yaml` and `policies/`. So an agent does not edit
-the live policy. It writes a candidate, then a human installs it.
+2. Learn the surface. Run `gryph policy schema` for the fields and `gryph policy builtin`
+   for real examples. Run `gryph policy list` to see what is already active.
 
-1. Write a candidate at a normal, unprotected path: `gryph policy init ./candidate.yml`.
-   This path is a candidate, not live policy. Gryph never resolves it.
-2. Edit `./candidate.yml` and add the rules.
-3. Validate the candidate alone: `gryph policy validate --file ./candidate.yml`.
-4. Hand it to a human. The human reviews the file and runs
-   `gryph policy install ./candidate.yml`, which validates it, checks it against the
-   merged policy, and copies it into `policies/`.
+3. Scaffold a draft. Run `gryph policy init ./gryph-policy/<name>.yaml` to write the fully
+   commented example to the workspace, then edit it. The path form writes to that exact
+   file, so it stays a draft. Do not use a bare name.
 
-`install` refuses a candidate that breaks the merge, for example a duplicate rule ID
-across files. Do not try to get an agent to write into `policies/` directly. The block is
-by design, and it is the human review gate.
+4. Author the rule. Match on `action_types`, tools, file patterns, commands, or URLs.
+   Narrow with a CEL `condition` only when the match criteria cannot express the rule.
 
-## Testing a rule
+5. Validate the draft in isolation.
 
-`gryph policy test` dry-runs a synthetic action through the merged policy. It does not
-touch the database and does not run an agent, so it is safe to run as often as you like.
+   ```bash
+   gryph policy validate --file ./gryph-policy/<name>.yaml
+   ```
 
-Build the action from flags that describe what an agent would do:
+   This compiles the one file without touching the active policy. Fix every error before
+   you hand it off.
+
+6. Hand the human an install command. Print the exact command and let the human run it.
+
+   ```bash
+   gryph policy install ./gryph-policy/<name>.yaml
+   ```
+
+   `install` validates the file, checks it against the merged policy, and copies it into
+   `policies/`. It refuses a file that breaks the merge, for example a duplicate rule ID.
+   The human runs it. You do not.
+
+## Testing
+
+`gryph policy validate --file` checks that a draft compiles. It does not run the rule.
+
+`gryph policy test` dry-runs a synthetic action, but it runs against the active merged
+policy, not against your draft file. So it reflects your rule only after the human
+installs it. Tell the human this. The full test is: the human installs the draft, then
+runs `gryph policy test` and checks receipts.
+
+Installing a draft to try it is safe. A new file can only add rules. It cannot weaken the
+built-in floor or remove another file's rules. To roll back, the human removes the file
+from `policies/`. After install, the human tests like this:
 
 ```bash
 gryph policy test --action command_exec --command "rm -rf /"
 gryph policy test --action file_write --path /app/prod/config.yaml
-gryph policy test --action tool_use --tool WebFetch --url https://example.com
+gryph policy receipts --decision block
 ```
 
-Use `--format json` when you want to read the decision and the matched rule
-programmatically. Set context counters with flags like `--context-files-written 25` to
-exercise rules that read `context.*` variables, without a live session. Run
-`gryph policy test --help` for the full flag list.
-
-For every rule, test three cases. This catches both false negatives and false positives:
-
-1. An action that must match the rule.
-2. An action that must not match, so the rule is not too broad.
-3. An action near the boundary, to confirm where the rule stops.
+Set context counters with flags like `--context-files-written 25` to exercise rules that
+read `context.*` variables. Run `gryph policy test --help` for the full flag list.
 
 ## Decisions and precedence
 
@@ -108,42 +113,20 @@ wins. The order, strongest first, is:
 
 `block > escalate > defer > guidance > warn > allow`
 
-Confirm the current decision names and semantics from `gryph policy schema` and the
-"Decisions" section of `docs/security-policy.md`. Precedence, not file order, decides. An
-`allow` can never override a `block`. Read `gryph policy builtin` to see what already
-fires, so a broad block does not swallow a case you meant to warn on.
+Confirm the current names from `gryph policy schema`. Precedence, not file order, decides.
+An `allow` can never override a `block`.
 
 ## Author safely
 
-These habits come from the user guide and prevent lockouts and silent misfires.
-
-- Start a new rule with `enabled: false`, or with `action: warn`. Watch the receipts with
-  `gryph policy receipts`, confirm it fires on the right actions, then promote it to
-  `block`.
-- Keep `policy.fail_mode: closed` during testing so a broken policy blocks actions
-  instead of allowing them silently. If a broken policy locks you out, set
-  `fail_mode: open`, fix the policy, and set it back. Do not ship `fail_mode: open`.
+- Start a new rule with `enabled: false`, or with `action: warn`. After the human
+  installs it, watch `gryph policy receipts`, confirm it fires on the right actions, then
+  promote it to `block`.
 - `disabled:` is a top-level list of rule IDs. It turns off your own rules. It is scoped
   to the file that declares the rule, so it cannot reach a rule in another file. It cannot
-  turn off a built-in rule. To turn the built-ins off, set
-  `policy.self_protection.enabled: false` in the config file. This turns off all of them
-  at once and is not recommended.
-- Namespace rule IDs by the file's purpose. IDs must be unique across every policy file,
-  and `install` rejects a candidate that collides.
-- Match criteria are cheap and readable. Reach for a CEL `condition` only when the match
-  criteria cannot express the rule.
-
-## Where things live
-
-- User policy: `policy.yaml` and the `policies/` directory, both in Gryph's config
-  directory. `gryph policy validate` prints the resolved paths, and `gryph policy list`
-  shows every active source.
-- Config keys under `policy:` (fail_mode, receipts, approval, self_protection) live in
-  the Gryph config file, not in a policy file.
-
-## Keep the guide honest
-
-`docs/security-policy.md` is the source of truth for authors. If you find the binary
-behaves differently from the doc, tell the user and prefer the binary, because it is the
-installed version. Do not copy large parts of the doc into this skill. Point at the doc
-and drive the binary.
+  turn off a built-in rule. To turn the built-ins off, the operator sets
+  `policy.self_protection.enabled: false` in the config file, which turns off all of them.
+- Namespace rule IDs by the file's purpose. IDs must be unique across every policy file.
+- Keep `policy.fail_mode: closed`. Do not advise `fail_mode: open` except as a temporary
+  step to recover from a lockout.
+- Config keys under `policy:` (fail_mode, receipts, approval, self_protection) live in the
+  Gryph config file, not in a policy file.

--- a/.claude/skills/gryph-policy-authoring/SKILL.md
+++ b/.claude/skills/gryph-policy-authoring/SKILL.md
@@ -72,9 +72,22 @@ there.
    ```
 
    This compiles the one file without touching the active policy. Fix every error before
-   you hand it off.
+   you continue.
 
-6. Hand the human an install command. Print the exact command and let the human run it.
+6. Dry-run the draft. `gryph policy test --file` evaluates a synthetic action against your
+   draft file plus the built-in rules, without resolving the active policy. Test three
+   cases per rule: an action that must match, an action that must not match, and an action
+   near the boundary.
+
+   ```bash
+   gryph policy test --file ./gryph-policy/<name>.yaml --action command_exec --command "rm -rf /"
+   gryph policy test --file ./gryph-policy/<name>.yaml --action file_write --path /app/prod/config.yaml
+   gryph policy test --file ./gryph-policy/<name>.yaml --action tool_use --tool WebFetch --url https://example.com
+   ```
+
+   Iterate: fix the rule, then repeat from step 5 until the decisions match intent.
+
+7. Hand the human an install command. Print the exact command and let the human run it.
 
    ```bash
    gryph policy install ./gryph-policy/<name>.yaml
@@ -86,22 +99,17 @@ there.
 
 ## Testing
 
-`gryph policy validate --file` checks that a draft compiles. It does not run the rule.
+`gryph policy validate --file <path>` checks that a draft compiles. `gryph policy test
+--file <path>` dry-runs a synthetic action against that draft plus the built-in rules. It
+does not touch the database and does not run an agent, so run it as often as you like.
 
-`gryph policy test` dry-runs a synthetic action, but it runs against the active merged
-policy, not against your draft file. So it reflects your rule only after the human
-installs it. Tell the human this. The full test is: the human installs the draft, then
-runs `gryph policy test` and checks receipts.
-
+`test --file` shows your rules and the built-ins. It does not include other installed
+files, because your draft is not yet merged with them. So the decision reflects your file
+against the built-in floor. The full test, with every active file, happens after the human
+installs the draft and runs plain `gryph policy test` and `gryph policy receipts`.
 Installing a draft to try it is safe. A new file can only add rules. It cannot weaken the
 built-in floor or remove another file's rules. To roll back, the human removes the file
-from `policies/`. After install, the human tests like this:
-
-```bash
-gryph policy test --action command_exec --command "rm -rf /"
-gryph policy test --action file_write --path /app/prod/config.yaml
-gryph policy receipts --decision block
-```
+from `policies/`.
 
 Set context counters with flags like `--context-files-written 25` to exercise rules that
 read `context.*` variables. Run `gryph policy test --help` for the full flag list.

--- a/.claude/skills/gryph-policy-authoring/SKILL.md
+++ b/.claude/skills/gryph-policy-authoring/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: gryph-policy-authoring
+description: Use when a user wants to author, edit, install, or test a Gryph security policy that governs what an AI coding agent may do. Trigger whenever the user wants Gryph to block, allow, warn on, or require approval for an agent action, wants to write or change a rule in a policy file, asks how to match a tool, command, file path, or URL, works with CEL conditions or context counters in a rule, wants to split policy into many files, or wants to dry-run and verify a policy with `gryph policy test`. Also trigger on phrases like "write a gryph policy", "add a policy rule", "make gryph block X", "test my policy", "install a policy", or "policy for my agent", even when the user does not name a file. This skill is for authoring and testing policy content, not for changing the policy engine code (use aarm-policy-layer for engine work under aarm/ or cli/policy.go).
+---
+
+# Authoring and Testing Gryph Policies
+
+Gryph mediates what an AI coding agent reads, writes, and runs. A policy is an ordered
+list of rules. Each rule matches an action and returns a decision. This skill helps a
+user author those rules and test them before they go live.
+
+Gryph resolves user policy from two places, both in Gryph's config directory: the global
+`policy.yaml`, and every `*.yaml` file in the `policies/` directory. Gryph merges its own
+built-in self-protection rules last. So the effective policy is your files plus the
+built-ins. Keep one global file, or split rules into many small files in `policies/`, one
+concern per file. Rule IDs must be unique across every file. Per-project policy is not
+wired today.
+
+Two sources of truth back this work. Use both. Do not author rules from memory.
+
+- `docs/security-policy.md` in this repo is the full author guide. It explains match
+  criteria, scope, CEL conditions, decisions, messages, receipts, deferrals, approval,
+  risk signals, and has worked examples. Read the section you need before you write a
+  rule.
+- The installed `gryph` binary is the authoritative, version-matched surface. Drive it
+  for the exact schema and for testing. The doc explains the concepts, the binary
+  confirms the fields.
+
+## The authoring loop
+
+Follow this loop. Each step feeds the next.
+
+1. Open a policy file. Run `gryph policy list` first to see every active source and its
+   rule count. To edit the global file, run `gryph policy edit`. To author a separate
+   file for one concern, run `gryph policy edit <name>`, which opens
+   `policies/<name>.yaml` and scaffolds it from the commented example when it is missing.
+   Run `gryph policy init` (or `gryph policy init <name>`) to scaffold the example
+   without opening an editor. Never run `gryph policy init --force` on an existing file
+   without explicit confirmation, because it overwrites the user's rules with the
+   example. `gryph policy validate` prints the resolved paths.
+
+2. Learn the surface from the binary, not from guesswork. Run `gryph policy schema` for
+   the authoritative rule fields, match criteria, and the decision set. Run
+   `gryph policy builtin` to read Gryph's own built-in rules as working, real-world
+   examples to imitate. If you are unsure a field exists or a decision is spelled right,
+   check `schema` before you write it.
+
+3. Author the rule. Match on `action_types`, tools, file patterns, commands, or URLs,
+   then narrow with a CEL `condition` when the match criteria are not enough. Read the
+   "Authoring a rule", "Match criteria", and "Conditions (CEL)" sections of
+   `docs/security-policy.md` for the field details.
+
+4. Validate. Run `gryph policy validate`. It compiles the merged policy and reports the
+   rule count. Fix every error before you test. `gryph policy edit` runs this for you on
+   save when the target is the global file or a named file.
+
+5. Test with synthetic actions. This is the core of getting a rule right. See the
+   testing section below.
+
+6. Iterate. Adjust the rule and repeat from step 4 until the decisions match intent.
+
+## Authoring as an agent: the review gate
+
+An agent cannot write into the config directory. The built-in self-protection rules
+block an agent `file_write` into `policy.yaml` and `policies/`. So an agent does not edit
+the live policy. It writes a candidate, then a human installs it.
+
+1. Write a candidate at a normal, unprotected path: `gryph policy init ./candidate.yml`.
+   This path is a candidate, not live policy. Gryph never resolves it.
+2. Edit `./candidate.yml` and add the rules.
+3. Validate the candidate alone: `gryph policy validate --file ./candidate.yml`.
+4. Hand it to a human. The human reviews the file and runs
+   `gryph policy install ./candidate.yml`, which validates it, checks it against the
+   merged policy, and copies it into `policies/`.
+
+`install` refuses a candidate that breaks the merge, for example a duplicate rule ID
+across files. Do not try to get an agent to write into `policies/` directly. The block is
+by design, and it is the human review gate.
+
+## Testing a rule
+
+`gryph policy test` dry-runs a synthetic action through the merged policy. It does not
+touch the database and does not run an agent, so it is safe to run as often as you like.
+
+Build the action from flags that describe what an agent would do:
+
+```bash
+gryph policy test --action command_exec --command "rm -rf /"
+gryph policy test --action file_write --path /app/prod/config.yaml
+gryph policy test --action tool_use --tool WebFetch --url https://example.com
+```
+
+Use `--format json` when you want to read the decision and the matched rule
+programmatically. Set context counters with flags like `--context-files-written 25` to
+exercise rules that read `context.*` variables, without a live session. Run
+`gryph policy test --help` for the full flag list.
+
+For every rule, test three cases. This catches both false negatives and false positives:
+
+1. An action that must match the rule.
+2. An action that must not match, so the rule is not too broad.
+3. An action near the boundary, to confirm where the rule stops.
+
+## Decisions and precedence
+
+A rule returns one decision. When several rules match one action, the most restrictive
+wins. The order, strongest first, is:
+
+`block > escalate > defer > guidance > warn > allow`
+
+Confirm the current decision names and semantics from `gryph policy schema` and the
+"Decisions" section of `docs/security-policy.md`. Precedence, not file order, decides. An
+`allow` can never override a `block`. Read `gryph policy builtin` to see what already
+fires, so a broad block does not swallow a case you meant to warn on.
+
+## Author safely
+
+These habits come from the user guide and prevent lockouts and silent misfires.
+
+- Start a new rule with `enabled: false`, or with `action: warn`. Watch the receipts with
+  `gryph policy receipts`, confirm it fires on the right actions, then promote it to
+  `block`.
+- Keep `policy.fail_mode: closed` during testing so a broken policy blocks actions
+  instead of allowing them silently. If a broken policy locks you out, set
+  `fail_mode: open`, fix the policy, and set it back. Do not ship `fail_mode: open`.
+- `disabled:` is a top-level list of rule IDs. It turns off your own rules. It is scoped
+  to the file that declares the rule, so it cannot reach a rule in another file. It cannot
+  turn off a built-in rule. To turn the built-ins off, set
+  `policy.self_protection.enabled: false` in the config file. This turns off all of them
+  at once and is not recommended.
+- Namespace rule IDs by the file's purpose. IDs must be unique across every policy file,
+  and `install` rejects a candidate that collides.
+- Match criteria are cheap and readable. Reach for a CEL `condition` only when the match
+  criteria cannot express the rule.
+
+## Where things live
+
+- User policy: `policy.yaml` and the `policies/` directory, both in Gryph's config
+  directory. `gryph policy validate` prints the resolved paths, and `gryph policy list`
+  shows every active source.
+- Config keys under `policy:` (fail_mode, receipts, approval, self_protection) live in
+  the Gryph config file, not in a policy file.
+
+## Keep the guide honest
+
+`docs/security-policy.md` is the source of truth for authors. If you find the binary
+behaves differently from the doc, tell the user and prefer the binary, because it is the
+installed version. Do not copy large parts of the doc into this skill. Point at the doc
+and drive the binary.

--- a/.claude/skills/gryph-policy-authoring/SKILL.md
+++ b/.claude/skills/gryph-policy-authoring/SKILL.md
@@ -107,9 +107,9 @@ does not touch the database and does not run an agent, so run it as often as you
 files, because your draft is not yet merged with them. So the decision reflects your file
 against the built-in floor. The full test, with every active file, happens after the human
 installs the draft and runs plain `gryph policy test` and `gryph policy receipts`.
-Installing a draft to try it is safe. A new file can only add rules. It cannot weaken the
-built-in floor or remove another file's rules. To roll back, the human removes the file
-from `policies/`.
+It is safe for the human to install a draft and try it. A new file can only add rules. It
+cannot weaken the built-in floor or remove another file's rules. To roll back, the human
+removes the file from `policies/`.
 
 Set context counters with flags like `--context-files-written 25` to exercise rules that
 read `context.*` variables. Run `gryph policy test --help` for the full flag list.

--- a/.claude/skills/gryph-policy-authoring/SKILL.md
+++ b/.claude/skills/gryph-policy-authoring/SKILL.md
@@ -105,10 +105,10 @@ does not touch the database and does not run an agent, so run it as often as you
 
 `test --file` shows your rules and the built-ins. It does not include other installed
 files, because your draft is not yet merged with them. So the decision reflects your file
-against the built-in floor. The full test, with every active file, happens after the human
+against the built-in rules. The full test, with every active file, happens after the human
 installs the draft and runs plain `gryph policy test` and `gryph policy receipts`.
 It is safe for the human to install a draft and try it. A new file can only add rules. It
-cannot weaken the built-in floor or remove another file's rules. To roll back, the human
+cannot remove the built-in rules or another file's rules. To roll back, the human
 removes the file from `policies/`.
 
 Set context counters with flags like `--context-files-written 25` to exercise rules that

--- a/aarm/loader/loader.go
+++ b/aarm/loader/loader.go
@@ -38,8 +38,9 @@ func (l *Loader) Sources() []Source {
 //
 // Built-in rules (from a *BuiltinSource) are isolated from user sources: they
 // are appended after user rules and are never removed by a disabled: entry, so
-// a user policy cannot weaken the self-protection rules. User rules may not use
-// the reserved BuiltinRuleIDPrefix; any that do are a load error.
+// a user policy cannot weaken the self-protection rules. A user rule may not use
+// the reserved BuiltinRuleIDPrefix. Any that does is a load error, even when the
+// same file also lists that ID under disabled:.
 func (l *Loader) Load(ctx context.Context) (*pdp.Policy, error) {
 	owner := make(map[string]string)
 	appliedDisabled := make(map[string]struct{})
@@ -59,6 +60,9 @@ func (l *Loader) Load(ctx context.Context) (*pdp.Policy, error) {
 			disabled := docDisabledSet(doc, isBuiltin)
 			matchedDisabled := make(map[string]struct{}, len(disabled))
 			for _, rule := range doc.Rules {
+				if !isBuiltin && strings.HasPrefix(rule.ID, BuiltinRuleIDPrefix) {
+					return nil, fmt.Errorf("loader: rule id %q in %s uses reserved prefix %q", rule.ID, src.Name(), BuiltinRuleIDPrefix)
+				}
 				if _, off := disabled[rule.ID]; off {
 					matchedDisabled[rule.ID] = struct{}{}
 					appliedDisabled[rule.ID] = struct{}{}
@@ -71,9 +75,6 @@ func (l *Loader) Load(ctx context.Context) (*pdp.Policy, error) {
 				if isBuiltin {
 					builtinRules = append(builtinRules, rule)
 					continue
-				}
-				if strings.HasPrefix(rule.ID, BuiltinRuleIDPrefix) {
-					return nil, fmt.Errorf("loader: rule id %q in %s uses reserved prefix %q", rule.ID, src.Name(), BuiltinRuleIDPrefix)
 				}
 				userRules = append(userRules, rule)
 			}
@@ -117,7 +118,7 @@ func docDisabledSet(doc *pdp.Policy, isBuiltin bool) map[string]struct{} {
 func warnUnmatchedDisabled(source string, disabled, matched map[string]struct{}) {
 	for id := range disabled {
 		if _, ok := matched[id]; !ok {
-			log.Warnf("loader: source %s disables rule %q that it does not define; disabled: only removes rules from the same file", source, id)
+			log.Warnf("loader: source %s lists rule %q under disabled but does not define it. A disabled entry removes only a rule from the same file", source, id)
 		}
 	}
 }

--- a/aarm/loader/loader.go
+++ b/aarm/loader/loader.go
@@ -33,8 +33,8 @@ func (l *Loader) Sources() []Source {
 // Load merges all sources in order. Duplicate rule IDs across sources are an
 // error. A document's disabled: removes only the rules that the same document
 // defines. This scope is uniform for every source, so the file that declares a
-// rule is the only file that can disable it. It matches the visible unit an
-// author or agent edits and keeps one file from reaching into another.
+// rule is the only file that can disable it. It matches the file an author or
+// agent edits. It stops one file from changing another file's rules.
 //
 // Built-in rules (from a *BuiltinSource) are isolated from user sources: they
 // are appended after user rules and are never removed by a disabled: entry, so

--- a/aarm/loader/loader.go
+++ b/aarm/loader/loader.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/safedep/dry/log"
 	"github.com/safedep/gryph/aarm/pdp"
 )
 
@@ -30,16 +31,18 @@ func (l *Loader) Sources() []Source {
 }
 
 // Load merges all sources in order. Duplicate rule IDs across sources are an
-// error. Rule IDs listed in a user source's Disabled are removed from the
-// merged rule set.
+// error. A document's disabled: removes only the rules that the same document
+// defines. This scope is uniform for every source, so the file that declares a
+// rule is the only file that can disable it. It matches the visible unit an
+// author or agent edits and keeps one file from reaching into another.
 //
 // Built-in rules (from a *BuiltinSource) are isolated from user sources: they
 // are appended after user rules and are never removed by a disabled: entry, so
-// a repo-local policy cannot weaken the self-protection rules. User rules may
-// not use the reserved BuiltinRuleIDPrefix; any that do are a load error.
+// a user policy cannot weaken the self-protection rules. User rules may not use
+// the reserved BuiltinRuleIDPrefix; any that do are a load error.
 func (l *Loader) Load(ctx context.Context) (*pdp.Policy, error) {
 	owner := make(map[string]string)
-	disabled := make(map[string]struct{})
+	appliedDisabled := make(map[string]struct{})
 	var userRules []pdp.Rule
 	var builtinRules []pdp.Rule
 
@@ -53,15 +56,14 @@ func (l *Loader) Load(ctx context.Context) (*pdp.Policy, error) {
 			if doc == nil {
 				continue
 			}
-			if !isBuiltin {
-				for _, id := range doc.Disabled {
-					if id == "" {
-						continue
-					}
-					disabled[id] = struct{}{}
-				}
-			}
+			disabled := docDisabledSet(doc, isBuiltin)
+			matchedDisabled := make(map[string]struct{}, len(disabled))
 			for _, rule := range doc.Rules {
+				if _, off := disabled[rule.ID]; off {
+					matchedDisabled[rule.ID] = struct{}{}
+					appliedDisabled[rule.ID] = struct{}{}
+					continue
+				}
 				if prev, ok := owner[rule.ID]; ok {
 					return nil, fmt.Errorf("loader: duplicate rule id %q in %s (already defined in %s)", rule.ID, src.Name(), prev)
 				}
@@ -75,26 +77,49 @@ func (l *Loader) Load(ctx context.Context) (*pdp.Policy, error) {
 				}
 				userRules = append(userRules, rule)
 			}
+			warnUnmatchedDisabled(src.Name(), disabled, matchedDisabled)
 		}
 	}
 
 	merged := &pdp.Policy{Rules: make([]pdp.Rule, 0, len(userRules)+len(builtinRules))}
-	for _, rule := range userRules {
-		if _, drop := disabled[rule.ID]; drop {
-			continue
-		}
-		merged.Rules = append(merged.Rules, rule)
-	}
+	merged.Rules = append(merged.Rules, userRules...)
 	// Built-in rules are appended last and are never filtered by disabled:.
 	merged.Rules = append(merged.Rules, builtinRules...)
-	if len(disabled) > 0 {
-		merged.Disabled = sortedKeys(disabled)
+	if len(appliedDisabled) > 0 {
+		merged.Disabled = sortedKeys(appliedDisabled)
 	}
 
 	if _, err := pdp.New(merged); err != nil {
 		return nil, fmt.Errorf("loader: compile merged policy: %w", err)
 	}
 	return merged, nil
+}
+
+// docDisabledSet returns the non-empty disabled IDs a user document declares.
+// A built-in document has no disabled scope, so it returns an empty set.
+func docDisabledSet(doc *pdp.Policy, isBuiltin bool) map[string]struct{} {
+	if isBuiltin {
+		return nil
+	}
+	set := make(map[string]struct{}, len(doc.Disabled))
+	for _, id := range doc.Disabled {
+		if id == "" {
+			continue
+		}
+		set[id] = struct{}{}
+	}
+	return set
+}
+
+// warnUnmatchedDisabled reports a disabled: entry that names no rule in the
+// same file. disabled: is scoped to the declaring file, so such an entry has no
+// effect. The warning surfaces a typo or a misplaced entry.
+func warnUnmatchedDisabled(source string, disabled, matched map[string]struct{}) {
+	for id := range disabled {
+		if _, ok := matched[id]; !ok {
+			log.Warnf("loader: source %s disables rule %q that it does not define; disabled: only removes rules from the same file", source, id)
+		}
+	}
 }
 
 func sortedKeys(set map[string]struct{}) []string {

--- a/aarm/loader/loader_test.go
+++ b/aarm/loader/loader_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/safedep/gryph/aarm/model"
 	"github.com/safedep/gryph/aarm/pdp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,18 +68,133 @@ func TestLoader_DuplicateRuleID(t *testing.T) {
 	assert.Contains(t, err.Error(), "dup")
 }
 
-func TestLoader_DisabledFilter(t *testing.T) {
+func TestLoader_DisabledScopedToSameFile(t *testing.T) {
 	dir := t.TempDir()
 	a := filepath.Join(dir, "a.yaml")
-	b := filepath.Join(dir, "b.yaml")
-	writeYAML(t, a, "version: \"1\"\nrules:\n  - id: keep\n    action: allow\n  - id: drop\n    action: block\n")
-	writeYAML(t, b, "version: \"1\"\nrules: []\ndisabled:\n  - drop\n")
+	writeYAML(t, a, "version: \"1\"\nrules:\n  - id: keep\n    action: allow\n  - id: drop\n    action: block\ndisabled:\n  - drop\n")
 
-	policy, err := New(NewFileSource(a), NewFileSource(b)).Load(context.Background())
+	policy, err := New(NewFileSource(a)).Load(context.Background())
 	require.NoError(t, err)
 	require.Len(t, policy.Rules, 1)
 	assert.Equal(t, "keep", policy.Rules[0].ID)
 	assert.Equal(t, []string{"drop"}, policy.Disabled)
+}
+
+func TestLoader_DisabledDoesNotReachOtherFile(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.yaml")
+	b := filepath.Join(dir, "b.yaml")
+	writeYAML(t, a, "version: \"1\"\nrules:\n  - id: keep\n    action: allow\n  - id: other-file-rule\n    action: block\n")
+	writeYAML(t, b, "version: \"1\"\nrules: []\ndisabled:\n  - other-file-rule\n")
+
+	policy, err := New(NewFileSource(a), NewFileSource(b)).Load(context.Background())
+	require.NoError(t, err)
+	ids := make([]string, 0, len(policy.Rules))
+	for _, r := range policy.Rules {
+		ids = append(ids, r.ID)
+	}
+	assert.ElementsMatch(t, []string{"keep", "other-file-rule"}, ids)
+	assert.Empty(t, policy.Disabled)
+}
+
+func TestLoader_DisabledFreesRuleIDForAnotherFile(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.yaml")
+	b := filepath.Join(dir, "b.yaml")
+	writeYAML(t, a, "version: \"1\"\nrules:\n  - id: shared\n    action: allow\ndisabled:\n  - shared\n")
+	writeYAML(t, b, "version: \"1\"\nrules:\n  - id: shared\n    action: block\n")
+
+	policy, err := New(NewFileSource(a), NewFileSource(b)).Load(context.Background())
+	require.NoError(t, err)
+	require.Len(t, policy.Rules, 1)
+	assert.Equal(t, "shared", policy.Rules[0].ID)
+	assert.Equal(t, model.DecisionBlock, policy.Rules[0].Action)
+}
+
+func TestDirSource_LoadsSortedDocuments(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, filepath.Join(dir, "b.yaml"), "version: \"1\"\nrules:\n  - id: r-b\n    action: block\n")
+	writeYAML(t, filepath.Join(dir, "a.yml"), "version: \"1\"\nrules:\n  - id: r-a\n    action: allow\n")
+	writeYAML(t, filepath.Join(dir, "notes.txt"), "ignored")
+
+	docs, err := NewDirSource(dir).Load(context.Background())
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+	require.Len(t, docs[0].Rules, 1)
+	require.Len(t, docs[1].Rules, 1)
+	assert.Equal(t, "r-a", docs[0].Rules[0].ID)
+	assert.Equal(t, "r-b", docs[1].Rules[0].ID)
+}
+
+func TestDirSource_MissingOptional(t *testing.T) {
+	docs, err := NewOptionalDirSource(filepath.Join(t.TempDir(), "absent")).Load(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, docs)
+}
+
+func TestDirSource_MissingRequired(t *testing.T) {
+	_, err := NewDirSource(filepath.Join(t.TempDir(), "absent")).Load(context.Background())
+	assert.Error(t, err)
+}
+
+func TestDirSource_MalformedFileNamesFile(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, filepath.Join(dir, "bad.yaml"), "rules:\n  - id: \"\"\n    action: allow\n")
+
+	_, err := NewDirSource(dir).Load(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad.yaml")
+}
+
+func TestLoader_MergesGlobalDirAndBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	global := filepath.Join(dir, "policy.yaml")
+	writeYAML(t, global, "version: \"1\"\nrules:\n  - id: g\n    action: warn\n")
+	pdir := filepath.Join(dir, "policies")
+	writeYAML(t, filepath.Join(pdir, "one.yaml"), "version: \"1\"\nrules:\n  - id: p1\n    action: allow\n")
+	writeYAML(t, filepath.Join(pdir, "two.yaml"), "version: \"1\"\nrules:\n  - id: p2\n    action: block\n")
+
+	policy, err := New(
+		NewOptionalFileSource(global),
+		NewOptionalDirSource(pdir),
+		NewBuiltinSource("**/.claude/settings.json"),
+	).Load(context.Background())
+	require.NoError(t, err)
+
+	ids := make([]string, 0, len(policy.Rules))
+	for _, r := range policy.Rules {
+		ids = append(ids, r.ID)
+	}
+	assert.Equal(t, []string{"g", "p1", "p2", builtinProtectedFilesRuleID, builtinProtectedCommandsRuleID}, ids)
+}
+
+func TestLoader_DuplicateRuleIDAcrossDirFiles(t *testing.T) {
+	pdir := t.TempDir()
+	writeYAML(t, filepath.Join(pdir, "one.yaml"), "version: \"1\"\nrules:\n  - id: dup\n    action: allow\n")
+	writeYAML(t, filepath.Join(pdir, "two.yaml"), "version: \"1\"\nrules:\n  - id: dup\n    action: block\n")
+
+	_, err := New(NewOptionalDirSource(pdir)).Load(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate rule id")
+	assert.Contains(t, err.Error(), "dup")
+}
+
+func TestLoader_UserDisabledCannotRemoveBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	global := filepath.Join(dir, "policy.yaml")
+	writeYAML(t, global, "version: \"1\"\nrules: []\ndisabled:\n  - "+builtinProtectedFilesRuleID+"\n")
+
+	policy, err := New(
+		NewOptionalFileSource(global),
+		NewBuiltinSource("**/.claude/settings.json"),
+	).Load(context.Background())
+	require.NoError(t, err)
+
+	ids := make([]string, 0, len(policy.Rules))
+	for _, r := range policy.Rules {
+		ids = append(ids, r.ID)
+	}
+	assert.Contains(t, ids, builtinProtectedFilesRuleID)
 }
 
 func TestLoader_EmptyReturnsEmptyPolicy(t *testing.T) {

--- a/aarm/loader/loader_test.go
+++ b/aarm/loader/loader_test.go
@@ -197,6 +197,16 @@ func TestLoader_UserDisabledCannotRemoveBuiltin(t *testing.T) {
 	assert.Contains(t, ids, builtinProtectedFilesRuleID)
 }
 
+func TestLoader_ReservedPrefixRejectedEvenWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.yaml")
+	writeYAML(t, a, "version: \"1\"\nrules:\n  - id: "+BuiltinRuleIDPrefix+"foo\n    action: allow\ndisabled:\n  - "+BuiltinRuleIDPrefix+"foo\n")
+
+	_, err := New(NewFileSource(a)).Load(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved prefix")
+}
+
 func TestLoader_EmptyReturnsEmptyPolicy(t *testing.T) {
 	policy, err := New().Load(context.Background())
 	require.NoError(t, err)

--- a/aarm/loader/sources.go
+++ b/aarm/loader/sources.go
@@ -3,7 +3,12 @@ package loader
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/safedep/gryph/aarm/pdp"
 )
@@ -35,4 +40,100 @@ func (s *FileSource) Load(_ context.Context) ([]*pdp.Policy, error) {
 		return nil, err
 	}
 	return []*pdp.Policy{policy}, nil
+}
+
+// DirSource loads every YAML policy file in one directory as a separate policy
+// document. It reads a single fixed, operator-owned directory. It is not a
+// configurable or repo-reaching source. Files load in sorted name order so the
+// merge is deterministic. A malformed file returns an error that names the
+// file.
+type DirSource struct {
+	Path     string
+	Optional bool
+}
+
+func NewDirSource(path string) *DirSource {
+	return &DirSource{Path: path}
+}
+
+func NewOptionalDirSource(path string) *DirSource {
+	return &DirSource{Path: path, Optional: true}
+}
+
+func (s *DirSource) Name() string {
+	return "dir:" + s.Path
+}
+
+func (s *DirSource) Load(_ context.Context) ([]*pdp.Policy, error) {
+	entries, err := os.ReadDir(s.Path)
+	if err != nil {
+		if s.Optional && errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	names := policyFileNames(entries)
+	docs := make([]*pdp.Policy, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(s.Path, name)
+		policy, err := pdp.LoadPolicyFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("policy file %s: %w", path, err)
+		}
+		docs = append(docs, policy)
+	}
+	return docs, nil
+}
+
+// PolicyFilesInDir returns the sorted YAML policy file paths in dir. A missing
+// directory returns no files and no error, so callers treat an absent policies
+// directory as empty. Callers that need per-file inspection (list, install)
+// share this scan with DirSource.
+func PolicyFilesInDir(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	names := policyFileNames(entries)
+	files := make([]string, len(names))
+	for i, name := range names {
+		files[i] = filepath.Join(dir, name)
+	}
+	return files, nil
+}
+
+func policyFileNames(entries []os.DirEntry) []string {
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if IsPolicyFileName(e.Name()) {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IsPolicyFileName reports whether name has a policy-file extension.
+func IsPolicyFileName(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".yaml", ".yml":
+		return true
+	default:
+		return false
+	}
+}
+
+// NormalizePolicyFileName appends the default .yaml extension when name has no
+// policy-file extension, so "x" and "x.yaml" resolve to the same file.
+func NormalizePolicyFileName(name string) string {
+	if IsPolicyFileName(name) {
+		return name
+	}
+	return name + ".yaml"
 }

--- a/aarm/loader/sources.go
+++ b/aarm/loader/sources.go
@@ -42,6 +42,23 @@ func (s *FileSource) Load(_ context.Context) ([]*pdp.Policy, error) {
 	return []*pdp.Policy{policy}, nil
 }
 
+// StaticSource yields policy documents the caller already parsed. It lets a
+// caller include in-memory content in a merge, without a re-read from disk.
+type StaticSource struct {
+	SourceName string
+	Docs       []*pdp.Policy
+}
+
+func NewStaticSource(name string, docs ...*pdp.Policy) *StaticSource {
+	return &StaticSource{SourceName: name, Docs: docs}
+}
+
+func (s *StaticSource) Name() string { return s.SourceName }
+
+func (s *StaticSource) Load(_ context.Context) ([]*pdp.Policy, error) {
+	return s.Docs, nil
+}
+
 // DirSource loads every YAML policy file in one directory as a separate policy
 // document. It reads a single fixed, operator-owned directory. It is not a
 // configurable or repo-reaching source. Files load in sorted name order so the

--- a/aarm/pdp/policy.example.yml
+++ b/aarm/pdp/policy.example.yml
@@ -17,20 +17,23 @@
 #     `block` with a placeholder message.
 #
 # Policy assembly:
-#   Gryph loads a single global policy from policy.yaml in its config directory.
-#   Write it there with `gryph policy init` and edit it with `gryph policy edit`.
-#   Built-in self-protection rules always load last and cannot be disabled by
-#   this file. To suppress one of your own rules without deleting it, list its
-#   ID under `disabled:`.
+#   Gryph merges three sources, in order: the global policy.yaml, every file in
+#   the policies/ directory, and the built-in rules. Write a file with
+#   `gryph policy init [name|path]` and edit it with `gryph policy edit`. List
+#   the active sources with `gryph policy list`. Rule IDs must be unique across
+#   all files, so namespace your IDs by the file's purpose. Built-in
+#   self-protection rules always load last and cannot be disabled by a policy
+#   file. To suppress one of your own rules without deleting it, list its ID
+#   under `disabled:`.
 
 version: "1"
 
 # `disabled:` is a list of rule IDs to remove from the merged policy. It is
-# the supported way for a project-local policy to neutralize a rule shipped by
-# a global policy without forking the global file.
+# scoped to this file. It removes only a rule that this same file defines. It
+# cannot disable a rule from another file or a built-in rule.
 #
 # disabled:
-#   - example-rule-id-from-some-other-file
+#   - a-rule-id-defined-in-this-file
 
 rules:
   # ---------------------------------------------------------------------------

--- a/cli/policy.go
+++ b/cli/policy.go
@@ -598,6 +598,7 @@ func newPolicyValidateCmd() *cobra.Command {
 func newPolicyTestCmd() *cobra.Command {
 	var (
 		format       string
+		file         string
 		actionType   string
 		tool         string
 		path         string
@@ -615,14 +616,21 @@ func newPolicyTestCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "test",
-		Short: "Dry-run a synthetic action through the merged policy",
+		Short: "Dry-run a synthetic action through the merged policy, or one file with --file",
+		Long: "Dry-runs a synthetic action through the active merged policy. With " +
+			"--file, dry-runs against one policy file plus the built-in rules, " +
+			"instead of the active policy. Use --file to check a draft in a " +
+			"workspace directory before you install it.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := loadApp()
 			if err != nil {
 				return err
 			}
 
-			ldr := buildPolicyLoader(app.Config, app.Paths)
+			ldr, err := testPolicyLoader(app, file)
+			if err != nil {
+				return err
+			}
 
 			policy, err := ldr.Load(cmd.Context())
 			if err != nil {
@@ -689,6 +697,7 @@ func newPolicyTestCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&format, "format", "table", "output format: table, json")
+	cmd.Flags().StringVar(&file, "file", "", "dry-run against one policy file plus the built-in rules, instead of the active policy")
 	cmd.Flags().StringVar(&actionType, "action", string(model.ActionToolUse), "action type")
 	cmd.Flags().StringVar(&tool, "tool", "", "tool name")
 	cmd.Flags().StringVar(&path, "path", "", "file path")
@@ -1252,6 +1261,25 @@ func selfProtectionEnabled(cfg *config.Config) bool {
 		return false
 	}
 	return cfg.EffectivePolicy().SelfProtection.Enabled
+}
+
+// testPolicyLoader builds the loader for `policy test`. With no file, it returns
+// the active merged policy. With a file, it returns that one file plus the
+// built-in rules, so an author can dry-run a workspace draft with faithful
+// precedence, without resolving the active policy.
+func testPolicyLoader(app *App, file string) (*loader.Loader, error) {
+	if file == "" {
+		return buildPolicyLoader(appConfig(app), appPaths(app)), nil
+	}
+	p, err := expandUserPath(file)
+	if err != nil {
+		return nil, err
+	}
+	sources := []loader.Source{loader.NewFileSource(p)}
+	if selfProtectionEnabled(appConfig(app)) {
+		sources = append(sources, loader.NewBuiltinSource(selfProtectionGlobs(appConfig(app), appPaths(app))...))
+	}
+	return loader.New(sources...), nil
 }
 
 func selfProtectionGlobs(cfg *config.Config, paths *config.Paths) []string {

--- a/cli/policy.go
+++ b/cli/policy.go
@@ -269,12 +269,28 @@ func newPolicyInitCmd() *cobra.Command {
 			if _, err := fmt.Fprintf(out, "%s Wrote example policy to %s\n", c.StatusOK(), c.Path(target.path)); err != nil {
 				return err
 			}
+			if target.managed() {
+				warnMergedPolicyConflict(cmd, app)
+			}
 			return printInitNextStep(out, c, target)
 		},
 	}
 
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite the target file if it already exists")
 	return cmd
+}
+
+// warnMergedPolicyConflict warns when the merged policy no longer loads after a
+// scaffold write into the config directory, for example because the example
+// reuses rule IDs that another file already defines. It does not fail. The file
+// is written, and the author edits the IDs to make them unique.
+func warnMergedPolicyConflict(cmd *cobra.Command, app *App) {
+	if _, err := buildPolicyLoader(appConfig(app), appPaths(app)).Load(cmd.Context()); err != nil {
+		c := policyColorizer(app)
+		out := cmd.OutOrStdout()
+		_, _ = fmt.Fprintf(out, "  %s %s\n", c.Warning("Warning:"), firstLine(err.Error()))
+		_, _ = fmt.Fprintf(out, "  %s\n", c.Dim("Edit the file so every rule ID is unique across your policy files."))
+	}
 }
 
 func printInitNextStep(out io.Writer, c *tui.Colorizer, target policyTarget) error {

--- a/cli/policy.go
+++ b/cli/policy.go
@@ -55,6 +55,8 @@ func NewPolicyCmd() *cobra.Command {
 	cmd.AddCommand(
 		newPolicyInitCmd(),
 		newPolicyEditCmd(),
+		newPolicyListCmd(),
+		newPolicyInstallCmd(),
 		newPolicySchemaCmd(),
 		newPolicyBuiltinCmd(),
 		newPolicyValidateCmd(),
@@ -109,6 +111,108 @@ func writeExamplePolicy(path string, force bool) error {
 	return nil
 }
 
+// policyTargetKind classifies the resolved target of init and edit.
+type policyTargetKind int
+
+const (
+	policyTargetGlobal policyTargetKind = iota // the global policy.yaml
+	policyTargetNamed                          // a named file in the policies directory
+	policyTargetPath                           // a literal off-tree candidate path
+)
+
+type policyTarget struct {
+	path string
+	kind policyTargetKind
+}
+
+// managed reports whether the target lives in the config directory, so an
+// author change to it is a live policy change worth a self-audit row.
+func (t policyTarget) managed() bool {
+	return t.kind == policyTargetGlobal || t.kind == policyTargetNamed
+}
+
+// resolvePolicyTarget maps the optional init/edit argument to a filesystem
+// target. A bare name resolves into the policies directory with a normalized
+// .yaml extension. A path (a separator, or a leading ., ~, or /) resolves
+// literally with ~ expanded. No argument targets the global policy file.
+func resolvePolicyTarget(paths *config.Paths, args []string) (policyTarget, error) {
+	if len(args) == 0 || args[0] == "" {
+		return policyTarget{path: config.DefaultPolicyFilePath(paths), kind: policyTargetGlobal}, nil
+	}
+	arg := args[0]
+	if isPolicyPathArg(arg) {
+		p, err := expandUserPath(arg)
+		if err != nil {
+			return policyTarget{}, err
+		}
+		return policyTarget{path: p, kind: policyTargetPath}, nil
+	}
+	name := loader.NormalizePolicyFileName(arg)
+	return policyTarget{path: filepath.Join(config.DefaultPolicyDirPath(paths), name), kind: policyTargetNamed}, nil
+}
+
+// isPolicyPathArg reports whether the argument is a path rather than a bare
+// name. A path holds a separator or starts with ., ~, or /.
+func isPolicyPathArg(arg string) bool {
+	if strings.HasPrefix(arg, ".") || strings.HasPrefix(arg, "~") || strings.HasPrefix(arg, "/") {
+		return true
+	}
+	return strings.ContainsRune(arg, '/') || strings.ContainsRune(arg, filepath.Separator)
+}
+
+// expandUserPath expands a leading ~ to the user home directory.
+func expandUserPath(p string) (string, error) {
+	if p != "~" && !strings.HasPrefix(p, "~/") {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", ErrConfig("resolve home directory", err)
+	}
+	if p == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, p[2:]), nil
+}
+
+// auditPolicyChange records a policy authoring action in the self-audit log so
+// every live policy change leaves a trail. It reuses the config_change action
+// and best-effort store, so a missing database never blocks authoring.
+func auditPolicyChange(ctx context.Context, app *App, operation, path string) {
+	if app == nil {
+		return
+	}
+	closeStore := openAuditStore(ctx, app)
+	defer closeStore()
+	if app.Store == nil {
+		return
+	}
+	details := map[string]interface{}{"operation": operation, "path": path}
+	if err := logSelfAudit(ctx, app.Store, SelfAuditActionConfigChange, "", details, SelfAuditResultSuccess, ""); err != nil {
+		log.Warnf("failed to record %s self-audit: %v", operation, err)
+	}
+}
+
+// openAuditStore opens the store on the App best-effort and returns a closer.
+// It mirrors the config-command pattern so authoring commands can audit
+// without a hard database dependency.
+func openAuditStore(ctx context.Context, app *App) func() {
+	if app == nil || app.Store != nil {
+		return func() {}
+	}
+	if err := config.EnsureDirectories(); err != nil {
+		return func() {}
+	}
+	if err := app.InitStore(ctx); err != nil {
+		return func() {}
+	}
+	return func() {
+		if err := app.Close(); err != nil {
+			log.Errorf("failed to close app: %v", err)
+		}
+	}
+}
+
 func resolveEditor() string {
 	if v := os.Getenv("VISUAL"); v != "" {
 		return v
@@ -136,58 +240,87 @@ func newPolicyInitCmd() *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Write the example policy to the global policy file",
-		Long: "Writes the embedded, fully commented example policy to the global " +
-			"Gryph policy file (policy.yaml in Gryph's config directory). Use this " +
-			"as the starting point for authoring your own rules, then edit it with " +
-			"`gryph policy edit`.",
-		Args: cobra.NoArgs,
+		Use:   "init [name|path]",
+		Short: "Write the example policy to a policy file",
+		Long: "Writes the embedded, fully commented example policy to a target. " +
+			"No argument targets the global policy.yaml. A bare name targets " +
+			"<name>.yaml in the policies directory. A path (with a separator or a " +
+			"leading ., ~, or /) targets that literal file, which is a candidate " +
+			"for a human to review and `gryph policy install`.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := loadApp()
 			if err != nil {
 				log.Warnf("loadApp failed during policy init, using resolved defaults: %v", err)
 			}
-			target := config.DefaultPolicyFilePath(appPaths(app))
-			if err := writeExamplePolicy(target, force); err != nil {
+			target, err := resolvePolicyTarget(appPaths(app), args)
+			if err != nil {
 				return err
+			}
+			if err := writeExamplePolicy(target.path, force); err != nil {
+				return err
+			}
+			if target.managed() {
+				auditPolicyChange(cmd.Context(), app, "policy_init", target.path)
 			}
 
 			c := policyColorizer(app)
 			out := cmd.OutOrStdout()
-			_, _ = fmt.Fprintf(out, "%s Wrote example policy to %s\n", c.StatusOK(), c.Path(target))
-			_, _ = fmt.Fprintf(out, "  %s\n", c.Dim("Next: `gryph policy edit` to customize, then `gryph policy validate`"))
-			return nil
+			if _, err := fmt.Fprintf(out, "%s Wrote example policy to %s\n", c.StatusOK(), c.Path(target.path)); err != nil {
+				return err
+			}
+			return printInitNextStep(out, c, target)
 		},
 	}
 
-	cmd.Flags().BoolVar(&force, "force", false, "overwrite the global policy file if it already exists")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite the target file if it already exists")
 	return cmd
+}
+
+func printInitNextStep(out io.Writer, c *tui.Colorizer, target policyTarget) error {
+	hint := "Next: `gryph policy edit` to customize, then `gryph policy validate`"
+	if target.kind == policyTargetPath {
+		hint = "This is a candidate. Ask a human to review and `gryph policy install " + target.path + "`."
+	}
+	_, err := fmt.Fprintf(out, "  %s\n", c.Dim(hint))
+	return err
 }
 
 func newPolicyEditCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "edit",
-		Short: "Open the global Gryph policy in your editor",
-		Long: "Opens the global Gryph policy (policy.yaml in Gryph's config " +
-			"directory) in $VISUAL or $EDITOR, falling back to vi. If the file " +
-			"does not exist it is first scaffolded from the documented example. " +
-			"After the editor exits the policy is validated and the result printed; " +
-			"a validation failure exits non-zero and leaves the file as written.",
-		Args: cobra.NoArgs,
+		Use:   "edit [name|path]",
+		Short: "Open a Gryph policy file in your editor",
+		Long: "Opens a policy file in $VISUAL or $EDITOR, falling back to vi. No " +
+			"argument targets the global policy.yaml. A bare name targets " +
+			"<name>.yaml in the policies directory. A path targets that literal " +
+			"file. A missing file is scaffolded from the example first. After the " +
+			"editor exits Gryph validates the result and prints it. A name or the " +
+			"global file validates the merged policy. A path validates that file " +
+			"alone. A validation failure exits non-zero and leaves the file as " +
+			"written.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := loadApp()
 			if err != nil {
 				log.Warnf("loadApp failed during policy edit, using resolved defaults: %v", err)
 			}
-			target := config.DefaultPolicyFilePath(appPaths(app))
-			if _, statErr := os.Stat(target); os.IsNotExist(statErr) {
-				if werr := writeExamplePolicy(target, false); werr != nil {
+			target, err := resolvePolicyTarget(appPaths(app), args)
+			if err != nil {
+				return err
+			}
+			if _, statErr := os.Stat(target.path); os.IsNotExist(statErr) {
+				if werr := writeExamplePolicy(target.path, false); werr != nil {
 					return werr
 				}
 			}
-			if err := runEditor(resolveEditor(), target); err != nil {
+			if err := runEditor(resolveEditor(), target.path); err != nil {
 				return ErrConfig("run editor", err)
+			}
+			if target.managed() {
+				auditPolicyChange(cmd.Context(), app, "policy_edit", target.path)
+			}
+			if target.kind == policyTargetPath {
+				return reportFileValidation(cmd, app, target.path)
 			}
 			return reportPolicyValidation(cmd, app)
 		},
@@ -282,6 +415,9 @@ func sourceToRow(src loader.Source) sourceRow {
 	case *loader.FileSource:
 		status, problem := fileSourceStatus(s.Path, s.Optional)
 		return sourceRow{Kind: "file", Path: s.Path, Optional: s.Optional, Status: status, Problem: problem}
+	case *loader.DirSource:
+		status, problem := dirSourceStatus(s.Path, s.Optional)
+		return sourceRow{Kind: "dir", Path: s.Path, Optional: s.Optional, Status: status, Problem: problem}
 	case *loader.BuiltinSource:
 		return sourceRow{
 			Kind:     "builtin",
@@ -306,6 +442,17 @@ func fileSourceStatus(path string, optional bool) (string, bool) {
 	}
 	if info.IsDir() {
 		return sourceStatusIsDirectory, true
+	}
+	return sourceStatusFound, false
+}
+
+func dirSourceStatus(path string, optional bool) (string, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return missingStatus(err, optional)
+	}
+	if !info.IsDir() {
+		return "not a directory", true
 	}
 	return sourceStatusFound, false
 }
@@ -387,18 +534,49 @@ func reportPolicyValidation(cmd *cobra.Command, app *App) error {
 	return nil
 }
 
+// reportFileValidation validates one policy file in isolation, without
+// resolving or merging the active policy. It is the shared check behind
+// `validate --file`, `edit <path>`, and the candidate step of `install`.
+func reportFileValidation(cmd *cobra.Command, app *App, path string) error {
+	policy, err := pdp.LoadPolicyFile(path)
+	if err != nil {
+		return ErrConfig("failed to validate policy file", err)
+	}
+	c := policyColorizer(app)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n",
+		c.StatusOK(),
+		c.Success(fmt.Sprintf("File valid: %d rules in %s", len(policy.Rules), path)))
+	return err
+}
+
 func newPolicyValidateCmd() *cobra.Command {
-	return &cobra.Command{
+	var file string
+
+	cmd := &cobra.Command{
 		Use:   "validate",
-		Short: "Validate the global Gryph policy",
+		Short: "Validate the merged Gryph policy, or one file with --file",
+		Long: "Validates the merged active policy (global file, policies directory, " +
+			"and built-ins). With --file, validates one policy file in isolation, " +
+			"without resolving or merging the active policy. Use --file to lint a " +
+			"candidate before install.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app, err := loadApp()
 			if err != nil {
 				return err
 			}
+			if file != "" {
+				path, err := expandUserPath(file)
+				if err != nil {
+					return err
+				}
+				return reportFileValidation(cmd, app, path)
+			}
 			return reportPolicyValidation(cmd, app)
 		},
 	}
+
+	cmd.Flags().StringVar(&file, "file", "", "validate a single policy file in isolation")
+	return cmd
 }
 
 func newPolicyTestCmd() *cobra.Command {
@@ -1032,21 +1210,32 @@ func (l *lazyPolicyCheck) recordAarmFailure(event *events.Event, action, label s
 var _ coresecurity.Check = (*lazyPolicyCheck)(nil)
 
 func buildPolicyLoader(cfg *config.Config, paths *config.Paths) *loader.Loader {
-	var policyCfg config.PolicyConfig
-	if cfg != nil {
-		policyCfg = cfg.EffectivePolicy()
-	}
+	return loader.New(policyLoaderSources(cfg, paths)...)
+}
+
+// policyLoaderSources returns the ordered policy sources: the global file, the
+// policies directory, and (when self-protection is on) the built-in source.
+// It is the single definition of the resolution order shared by the loader and
+// the inspection commands.
+func policyLoaderSources(cfg *config.Config, paths *config.Paths) []loader.Source {
 	if paths == nil {
 		paths = config.ResolvePaths()
 	}
-
 	sources := []loader.Source{
 		loader.NewOptionalFileSource(config.DefaultPolicyFilePath(paths)),
+		loader.NewOptionalDirSource(config.DefaultPolicyDirPath(paths)),
 	}
-	if policyCfg.SelfProtection.Enabled {
+	if selfProtectionEnabled(cfg) {
 		sources = append(sources, loader.NewBuiltinSource(selfProtectionGlobs(cfg, paths)...))
 	}
-	return loader.New(sources...)
+	return sources
+}
+
+func selfProtectionEnabled(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.EffectivePolicy().SelfProtection.Enabled
 }
 
 func selfProtectionGlobs(cfg *config.Config, paths *config.Paths) []string {

--- a/cli/policy.go
+++ b/cli/policy.go
@@ -1250,6 +1250,11 @@ func policyLoaderSources(cfg *config.Config, paths *config.Paths) []loader.Sourc
 		loader.NewOptionalFileSource(config.DefaultPolicyFilePath(paths)),
 		loader.NewOptionalDirSource(config.DefaultPolicyDirPath(paths)),
 	}
+	return appendBuiltinSource(sources, cfg, paths)
+}
+
+// appendBuiltinSource adds the self-protection source when it is enabled.
+func appendBuiltinSource(sources []loader.Source, cfg *config.Config, paths *config.Paths) []loader.Source {
 	if selfProtectionEnabled(cfg) {
 		sources = append(sources, loader.NewBuiltinSource(selfProtectionGlobs(cfg, paths)...))
 	}
@@ -1275,10 +1280,7 @@ func testPolicyLoader(app *App, file string) (*loader.Loader, error) {
 	if err != nil {
 		return nil, err
 	}
-	sources := []loader.Source{loader.NewFileSource(p)}
-	if selfProtectionEnabled(appConfig(app)) {
-		sources = append(sources, loader.NewBuiltinSource(selfProtectionGlobs(appConfig(app), appPaths(app))...))
-	}
+	sources := appendBuiltinSource([]loader.Source{loader.NewFileSource(p)}, appConfig(app), appPaths(app))
 	return loader.New(sources...), nil
 }
 

--- a/cli/policy_authoring.go
+++ b/cli/policy_authoring.go
@@ -171,9 +171,9 @@ func newPolicyInstallCmd() *cobra.Command {
 				return ErrConfig("candidate policy is not valid", err)
 			}
 
-			destName := filepath.Base(src)
-			if name != "" {
-				destName = loader.NormalizePolicyFileName(name)
+			destName, err := installDestName(src, name)
+			if err != nil {
+				return err
 			}
 			dest := filepath.Join(config.DefaultPolicyDirPath(paths), destName)
 
@@ -211,6 +211,21 @@ func newPolicyInstallCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing installed file")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate and show the destination without copying")
 	return cmd
+}
+
+// installDestName resolves the destination file name for install. It rejects a
+// name with a path component or a parent reference, so install always writes a
+// direct YAML child of the policies directory that DirSource loads. It
+// normalizes a missing extension to .yaml.
+func installDestName(src, name string) (string, error) {
+	raw := name
+	if raw == "" {
+		raw = filepath.Base(src)
+	}
+	if raw == "." || raw == ".." || strings.ContainsAny(raw, `/\`) {
+		return "", ErrConfig("invalid policy name", fmt.Errorf("%q must be a plain file name without a path", raw))
+	}
+	return loader.NormalizePolicyFileName(raw), nil
 }
 
 // checkMergedWithCandidate loads the policy that would result after install, so

--- a/cli/policy_authoring.go
+++ b/cli/policy_authoring.go
@@ -79,7 +79,27 @@ func policyFileRow(source, path string) policyListRow {
 	if err != nil {
 		return policyListRow{source: source, file: filepath.Base(path), err: firstLine(err.Error())}
 	}
-	return policyListRow{source: source, file: filepath.Base(path), rules: len(policy.Rules)}
+	return policyListRow{source: source, file: filepath.Base(path), rules: activeRuleCount(policy)}
+}
+
+// activeRuleCount counts the rules a file contributes to the merge. It drops the
+// rules the same file removes with its own disabled: list, so per-file counts
+// match what the file adds.
+func activeRuleCount(p *pdp.Policy) int {
+	if len(p.Disabled) == 0 {
+		return len(p.Rules)
+	}
+	disabled := make(map[string]struct{}, len(p.Disabled))
+	for _, id := range p.Disabled {
+		disabled[id] = struct{}{}
+	}
+	count := 0
+	for _, r := range p.Rules {
+		if _, off := disabled[r.ID]; !off {
+			count++
+		}
+	}
+	return count
 }
 
 func builtinListRow(cfg *config.Config, paths *config.Paths) policyListRow {
@@ -166,7 +186,11 @@ func newPolicyInstallCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			candidate, err := pdp.LoadPolicyFile(src)
+			data, err := os.ReadFile(src)
+			if err != nil {
+				return ErrConfig("read candidate file", err)
+			}
+			candidate, err := pdp.ParsePolicy(data)
 			if err != nil {
 				return ErrConfig("candidate policy is not valid", err)
 			}
@@ -181,7 +205,7 @@ func newPolicyInstallCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			_, _ = fmt.Fprintf(out, "%s Validated %s (%d rules)\n", c.StatusOK(), c.Path(src), len(candidate.Rules))
 
-			if err := checkMergedWithCandidate(cfg, paths, dest, src); err != nil {
+			if err := checkMergedWithCandidate(cfg, paths, dest, "file:"+src, candidate); err != nil {
 				return err
 			}
 
@@ -196,7 +220,7 @@ func newPolicyInstallCmd() *cobra.Command {
 			if fileExists(dest) && !force {
 				return ErrConfig(fmt.Sprintf("refusing to overwrite %s (use --force to replace)", dest), fmt.Errorf("%s exists", dest))
 			}
-			if err := copyPolicyFile(src, dest); err != nil {
+			if err := writeInstalledPolicy(dest, data); err != nil {
 				return err
 			}
 			auditPolicyChange(cmd.Context(), app, "policy_install", dest)
@@ -230,10 +254,12 @@ func installDestName(src, name string) (string, error) {
 
 // checkMergedWithCandidate loads the policy that would result after install, so
 // a candidate that is valid alone but breaks the merge (a duplicate rule ID
-// across files, a reserved prefix) is refused before it is copied. It excludes
-// the file the candidate would replace, so a force re-install of an updated
-// file does not collide with the version it replaces.
-func checkMergedWithCandidate(cfg *config.Config, paths *config.Paths, dest, candidatePath string) error {
+// across files, a reserved prefix) is refused before it is written. It validates
+// the parsed candidate, not a re-read of the file, so the merge check and the
+// write see the same content. It excludes the file the candidate would replace,
+// so a force re-install of an updated file does not collide with the version it
+// replaces.
+func checkMergedWithCandidate(cfg *config.Config, paths *config.Paths, dest, candidateName string, candidate *pdp.Policy) error {
 	if paths == nil {
 		paths = config.ResolvePaths()
 	}
@@ -244,26 +270,29 @@ func checkMergedWithCandidate(cfg *config.Config, paths *config.Paths, dest, can
 	if err != nil {
 		return ErrConfig("scan policies directory", err)
 	}
+	destInfo, destErr := os.Stat(dest)
 	for _, f := range files {
-		if filepath.Clean(f) == filepath.Clean(dest) {
-			continue
+		if destErr == nil {
+			if info, statErr := os.Stat(f); statErr == nil && os.SameFile(info, destInfo) {
+				continue
+			}
 		}
 		sources = append(sources, loader.NewFileSource(f))
 	}
-	sources = append(sources, loader.NewFileSource(candidatePath))
-	if selfProtectionEnabled(cfg) {
-		sources = append(sources, loader.NewBuiltinSource(selfProtectionGlobs(cfg, paths)...))
-	}
+	sources = append(sources, loader.NewStaticSource(candidateName, candidate))
+	sources = appendBuiltinSource(sources, cfg, paths)
 	if _, err := loader.New(sources...).Load(context.Background()); err != nil {
 		return ErrConfig("candidate conflicts with the active policy", err)
 	}
 	return nil
 }
 
-func copyPolicyFile(src, dest string) error {
-	data, err := os.ReadFile(src)
-	if err != nil {
-		return ErrConfig("read candidate file", err)
+// writeInstalledPolicy writes the validated candidate bytes to dest. It refuses
+// a symlink at dest, so a planted link cannot redirect the write out of the
+// policies directory.
+func writeInstalledPolicy(dest string, data []byte) error {
+	if info, err := os.Lstat(dest); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return ErrConfig("refusing to write through a symlink", fmt.Errorf("%s is a symlink", dest))
 	}
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		return ErrConfig("create policies directory", err)

--- a/cli/policy_authoring.go
+++ b/cli/policy_authoring.go
@@ -1,0 +1,272 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/safedep/dry/log"
+	"github.com/safedep/gryph/aarm/loader"
+	"github.com/safedep/gryph/aarm/pdp"
+	"github.com/safedep/gryph/config"
+	"github.com/safedep/gryph/tui"
+	"github.com/spf13/cobra"
+)
+
+func newPolicyListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List the active policy sources and rule counts",
+		Long: "Lists every active policy source with its rule count: the global " +
+			"file, each file in the policies directory, and the built-ins. A file " +
+			"that fails to parse is shown with an error marker and does not hide " +
+			"the rest. The final line reports the merged rule total, or a conflict " +
+			"that stops the merge.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := loadApp()
+			if err != nil {
+				log.Warnf("loadApp failed during policy list, using resolved defaults: %v", err)
+			}
+			cfg := appConfig(app)
+			paths := appPaths(app)
+			rows := gatherPolicyListRows(cfg, paths)
+			merged, mergeErr := buildPolicyLoader(cfg, paths).Load(cmd.Context())
+			renderPolicyList(cmd.OutOrStdout(), policyColorizer(app), rows, merged, mergeErr)
+			return nil
+		},
+	}
+}
+
+type policyListRow struct {
+	source string
+	file   string
+	rules  int
+	err    string
+}
+
+// gatherPolicyListRows loads each source on its own so one broken file does not
+// hide the rest. It shares source identity and file scanning with the loader.
+func gatherPolicyListRows(cfg *config.Config, paths *config.Paths) []policyListRow {
+	var rows []policyListRow
+
+	globalPath := config.DefaultPolicyFilePath(paths)
+	if fileExists(globalPath) {
+		rows = append(rows, policyFileRow("global", globalPath))
+	}
+
+	dir := config.DefaultPolicyDirPath(paths)
+	files, err := loader.PolicyFilesInDir(dir)
+	if err != nil {
+		rows = append(rows, policyListRow{source: "policies", file: dir, err: firstLine(err.Error())})
+	}
+	for _, f := range files {
+		rows = append(rows, policyFileRow("policies", f))
+	}
+
+	if selfProtectionEnabled(cfg) {
+		rows = append(rows, builtinListRow(cfg, paths))
+	}
+	return rows
+}
+
+func policyFileRow(source, path string) policyListRow {
+	policy, err := pdp.LoadPolicyFile(path)
+	if err != nil {
+		return policyListRow{source: source, file: filepath.Base(path), err: firstLine(err.Error())}
+	}
+	return policyListRow{source: source, file: filepath.Base(path), rules: len(policy.Rules)}
+}
+
+func builtinListRow(cfg *config.Config, paths *config.Paths) policyListRow {
+	src := loader.NewBuiltinSource(selfProtectionGlobs(cfg, paths)...)
+	docs, err := src.Load(context.Background())
+	if err != nil {
+		return policyListRow{source: "builtin", file: "(embedded self-protection)", err: firstLine(err.Error())}
+	}
+	rules := 0
+	for _, d := range docs {
+		if d != nil {
+			rules += len(d.Rules)
+		}
+	}
+	return policyListRow{source: "builtin", file: "(embedded self-protection)", rules: rules}
+}
+
+func renderPolicyList(w io.Writer, c *tui.Colorizer, rows []policyListRow, merged *pdp.Policy, mergeErr error) {
+	const srcHead, fileHead = "SOURCE", "FILE"
+	srcWidth, fileWidth := len(srcHead), len(fileHead)
+	for _, r := range rows {
+		if len(r.source) > srcWidth {
+			srcWidth = len(r.source)
+		}
+		if len(r.file) > fileWidth {
+			fileWidth = len(r.file)
+		}
+	}
+
+	_, _ = fmt.Fprintf(w, "%s  %s  %s\n",
+		c.Dim(fmt.Sprintf("%-*s", srcWidth, srcHead)),
+		c.Dim(fmt.Sprintf("%-*s", fileWidth, fileHead)),
+		c.Dim("RULES"))
+	for _, r := range rows {
+		rulesCell := c.Number(fmt.Sprintf("%d", r.rules))
+		if r.err != "" {
+			rulesCell = c.Warning("! " + r.err)
+		}
+		_, _ = fmt.Fprintf(w, "%s  %s  %s\n",
+			c.Cyan(fmt.Sprintf("%-*s", srcWidth, r.source)),
+			fmt.Sprintf("%-*s", fileWidth, r.file),
+			rulesCell)
+	}
+
+	_, _ = fmt.Fprintln(w)
+	switch {
+	case mergeErr != nil:
+		_, _ = fmt.Fprintf(w, "%s %s\n", c.Warning("Merge conflict:"), firstLine(mergeErr.Error()))
+	case merged != nil:
+		_, _ = fmt.Fprintf(w, "%s\n", c.Success(fmt.Sprintf("%d rules merged.", len(merged.Rules))))
+		if len(rows) == 1 && rows[0].source == "builtin" {
+			_, _ = fmt.Fprintf(w, "%s\n", c.Dim("Only built-in rules are active. Run `gryph policy init` to author your own."))
+		}
+	}
+}
+
+func newPolicyInstallCmd() *cobra.Command {
+	var (
+		name   string
+		force  bool
+		dryRun bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "install <path>",
+		Short: "Validate a candidate policy file and copy it into the policies directory",
+		Long: "Validates a candidate policy file, then copies it into the policies " +
+			"directory so it becomes active. The destination name is the source " +
+			"basename, or <name>.yaml with --name. install refuses to overwrite an " +
+			"existing file unless --force. --dry-run validates and shows the " +
+			"destination without copying. install is the human-run promote step. An " +
+			"agent cannot write into the protected policies directory with its file " +
+			"tools.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			app, err := loadApp()
+			if err != nil {
+				log.Warnf("loadApp failed during policy install, using resolved defaults: %v", err)
+			}
+			cfg := appConfig(app)
+			paths := appPaths(app)
+
+			src, err := expandUserPath(args[0])
+			if err != nil {
+				return err
+			}
+			candidate, err := pdp.LoadPolicyFile(src)
+			if err != nil {
+				return ErrConfig("candidate policy is not valid", err)
+			}
+
+			destName := filepath.Base(src)
+			if name != "" {
+				destName = loader.NormalizePolicyFileName(name)
+			}
+			dest := filepath.Join(config.DefaultPolicyDirPath(paths), destName)
+
+			c := policyColorizer(app)
+			out := cmd.OutOrStdout()
+			_, _ = fmt.Fprintf(out, "%s Validated %s (%d rules)\n", c.StatusOK(), c.Path(src), len(candidate.Rules))
+
+			if err := checkMergedWithCandidate(cfg, paths, dest, src); err != nil {
+				return err
+			}
+
+			if dryRun {
+				_, _ = fmt.Fprintf(out, "  Would install to %s (dry run, nothing written)\n", c.Path(dest))
+				if fileExists(dest) {
+					_, _ = fmt.Fprintf(out, "  %s\n", c.Dim("Destination exists. install needs --force to overwrite."))
+				}
+				return nil
+			}
+
+			if fileExists(dest) && !force {
+				return ErrConfig(fmt.Sprintf("refusing to overwrite %s (use --force to replace)", dest), fmt.Errorf("%s exists", dest))
+			}
+			if err := copyPolicyFile(src, dest); err != nil {
+				return err
+			}
+			auditPolicyChange(cmd.Context(), app, "policy_install", dest)
+
+			_, _ = fmt.Fprintf(out, "%s Installed to %s\n", c.StatusOK(), c.Path(dest))
+			_, _ = fmt.Fprintf(out, "  %s\n", c.Dim("Run `gryph policy list` to confirm, `gryph policy test` to check behavior."))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "destination file name (the .yaml suffix is optional)")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing installed file")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate and show the destination without copying")
+	return cmd
+}
+
+// checkMergedWithCandidate loads the policy that would result after install, so
+// a candidate that is valid alone but breaks the merge (a duplicate rule ID
+// across files, a reserved prefix) is refused before it is copied. It excludes
+// the file the candidate would replace, so a force re-install of an updated
+// file does not collide with the version it replaces.
+func checkMergedWithCandidate(cfg *config.Config, paths *config.Paths, dest, candidatePath string) error {
+	if paths == nil {
+		paths = config.ResolvePaths()
+	}
+	sources := []loader.Source{
+		loader.NewOptionalFileSource(config.DefaultPolicyFilePath(paths)),
+	}
+	files, err := loader.PolicyFilesInDir(config.DefaultPolicyDirPath(paths))
+	if err != nil {
+		return ErrConfig("scan policies directory", err)
+	}
+	for _, f := range files {
+		if filepath.Clean(f) == filepath.Clean(dest) {
+			continue
+		}
+		sources = append(sources, loader.NewFileSource(f))
+	}
+	sources = append(sources, loader.NewFileSource(candidatePath))
+	if selfProtectionEnabled(cfg) {
+		sources = append(sources, loader.NewBuiltinSource(selfProtectionGlobs(cfg, paths)...))
+	}
+	if _, err := loader.New(sources...).Load(context.Background()); err != nil {
+		return ErrConfig("candidate conflicts with the active policy", err)
+	}
+	return nil
+}
+
+func copyPolicyFile(src, dest string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return ErrConfig("read candidate file", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return ErrConfig("create policies directory", err)
+	}
+	if err := os.WriteFile(dest, data, 0o644); err != nil {
+		return ErrConfig("write installed policy", err)
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}

--- a/cli/policy_authoring_test.go
+++ b/cli/policy_authoring_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/safedep/gryph/aarm/pdp"
 	"github.com/safedep/gryph/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -211,6 +212,55 @@ func TestInstallDestName(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestPolicyInstall_WritesValidatedBytes(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	cand := filepath.Join(t.TempDir(), "cand.yaml")
+	content := "version: \"1\"\nrules:\n  - id: team-rule\n    action: block\n"
+	writePolicyFile(t, cand, content)
+
+	_, err := runPolicyCmd(t, newPolicyInstallCmd(), cand, "--name", "team")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(gryphConfigDir(root), "policies", "team.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got))
+}
+
+func TestPolicyInstall_RefusesSymlinkDest(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	pdir := filepath.Join(gryphConfigDir(root), "policies")
+	require.NoError(t, os.MkdirAll(pdir, 0o755))
+
+	target := filepath.Join(t.TempDir(), "outside.yaml")
+	targetContent := "version: \"1\"\nrules: []\n"
+	writePolicyFile(t, target, targetContent)
+	require.NoError(t, os.Symlink(target, filepath.Join(pdir, "evil.yaml")))
+
+	cand := filepath.Join(t.TempDir(), "cand.yaml")
+	writePolicyFile(t, cand, "version: \"1\"\nrules:\n  - id: r\n    action: allow\n")
+
+	_, err := runPolicyCmd(t, newPolicyInstallCmd(), cand, "--name", "evil", "--force")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, targetContent, string(got))
+}
+
+func TestActiveRuleCount(t *testing.T) {
+	withDisabled := &pdp.Policy{
+		Rules:    []pdp.Rule{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+		Disabled: []string{"b"},
+	}
+	assert.Equal(t, 2, activeRuleCount(withDisabled))
+
+	plain := &pdp.Policy{Rules: []pdp.Rule{{ID: "a"}}}
+	assert.Equal(t, 1, activeRuleCount(plain))
 }
 
 func TestPolicyInstall_RejectsPathName(t *testing.T) {

--- a/cli/policy_authoring_test.go
+++ b/cli/policy_authoring_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/safedep/gryph/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runPolicyCmd(t *testing.T, cmd *cobra.Command, args ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func writePolicyFile(t *testing.T, path, body string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+}
+
+func gryphConfigDir(root string) string { return filepath.Join(root, "gryph") }
+
+func TestResolvePolicyTarget(t *testing.T) {
+	paths := &config.Paths{ConfigDir: "/cfg"}
+	cases := []struct {
+		name     string
+		args     []string
+		wantPath string
+		wantKind policyTargetKind
+	}{
+		{"no arg targets global", nil, "/cfg/policy.yaml", policyTargetGlobal},
+		{"bare name normalizes extension", []string{"guard"}, "/cfg/policies/guard.yaml", policyTargetNamed},
+		{"bare name keeps yaml", []string{"guard.yaml"}, "/cfg/policies/guard.yaml", policyTargetNamed},
+		{"bare name keeps yml", []string{"guard.yml"}, "/cfg/policies/guard.yml", policyTargetNamed},
+		{"dot path is literal", []string{"./x.yml"}, "./x.yml", policyTargetPath},
+		{"separator path is literal", []string{"sub/x.yaml"}, "sub/x.yaml", policyTargetPath},
+		{"absolute path is literal", []string{"/tmp/x.yaml"}, "/tmp/x.yaml", policyTargetPath},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolvePolicyTarget(paths, tc.args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPath, got.path)
+			assert.Equal(t, tc.wantKind, got.kind)
+		})
+	}
+}
+
+func TestResolvePolicyTarget_TildeExpands(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	got, err := resolvePolicyTarget(&config.Paths{ConfigDir: "/cfg"}, []string{"~/x.yml"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "x.yml"), got.path)
+	assert.Equal(t, policyTargetPath, got.kind)
+}
+
+func TestPolicyInit_Forms(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	cfgDir := gryphConfigDir(root)
+
+	_, err := runPolicyCmd(t, newPolicyInitCmd())
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(cfgDir, "policy.yaml"))
+
+	_, err = runPolicyCmd(t, newPolicyInitCmd(), "agent-guardrails")
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(cfgDir, "policies", "agent-guardrails.yaml"))
+
+	cand := filepath.Join(t.TempDir(), "cand.yml")
+	out, err := runPolicyCmd(t, newPolicyInitCmd(), cand)
+	require.NoError(t, err)
+	assert.Contains(t, out, "candidate")
+	assert.FileExists(t, cand)
+}
+
+func TestPolicyInit_RefusesOverwriteWithoutForce(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+
+	_, err := runPolicyCmd(t, newPolicyInitCmd(), "guard")
+	require.NoError(t, err)
+	_, err = runPolicyCmd(t, newPolicyInitCmd(), "guard")
+	require.Error(t, err)
+	_, err = runPolicyCmd(t, newPolicyInitCmd(), "guard", "--force")
+	require.NoError(t, err)
+}
+
+func TestPolicyEdit_NameValidatesMerged(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "true")
+
+	out, err := runPolicyCmd(t, newPolicyEditCmd(), "guard")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Policy valid")
+	assert.FileExists(t, filepath.Join(gryphConfigDir(root), "policies", "guard.yaml"))
+}
+
+func TestPolicyEdit_PathValidatesFileAlone(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", "true")
+
+	cand := filepath.Join(t.TempDir(), "cand.yml")
+	out, err := runPolicyCmd(t, newPolicyEditCmd(), cand)
+	require.NoError(t, err)
+	assert.Contains(t, out, "File valid")
+}
+
+func TestPolicyValidateFile(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+
+	good := filepath.Join(t.TempDir(), "good.yaml")
+	writePolicyFile(t, good, "version: \"1\"\nrules:\n  - id: ok\n    action: allow\n")
+	out, err := runPolicyCmd(t, newPolicyValidateCmd(), "--file", good)
+	require.NoError(t, err)
+	assert.Contains(t, out, "File valid")
+
+	bad := filepath.Join(t.TempDir(), "bad.yaml")
+	writePolicyFile(t, bad, "rules:\n  - id: \"\"\n    action: allow\n")
+	_, err = runPolicyCmd(t, newPolicyValidateCmd(), "--file", bad)
+	require.Error(t, err)
+}
+
+func TestPolicyInstall_LifecycleAndList(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	cfgDir := gryphConfigDir(root)
+	dest := filepath.Join(cfgDir, "policies", "no-prod.yaml")
+
+	cand := filepath.Join(t.TempDir(), "cand.yaml")
+	writePolicyFile(t, cand, "version: \"1\"\nrules:\n  - id: team-no-prod\n    action: block\n")
+
+	out, err := runPolicyCmd(t, newPolicyInstallCmd(), cand, "--name", "no-prod", "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Would install")
+	assert.NoFileExists(t, dest)
+
+	out, err = runPolicyCmd(t, newPolicyInstallCmd(), cand, "--name", "no-prod")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed to")
+	assert.FileExists(t, dest)
+
+	_, err = runPolicyCmd(t, newPolicyInstallCmd(), cand, "--name", "no-prod")
+	require.Error(t, err)
+
+	// force re-install of the same rule IDs must not collide with the file it replaces
+	_, err = runPolicyCmd(t, newPolicyInstallCmd(), cand, "--name", "no-prod", "--force")
+	require.NoError(t, err)
+
+	out, err = runPolicyCmd(t, newPolicyListCmd())
+	require.NoError(t, err)
+	assert.Contains(t, out, "no-prod.yaml")
+	assert.Contains(t, out, "rules merged.")
+}
+
+func TestPolicyInstall_RefusesMergeConflict(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	writePolicyFile(t, filepath.Join(gryphConfigDir(root), "policy.yaml"),
+		"version: \"1\"\nrules:\n  - id: dup\n    action: allow\n")
+
+	cand := filepath.Join(t.TempDir(), "cand.yaml")
+	writePolicyFile(t, cand, "version: \"1\"\nrules:\n  - id: dup\n    action: block\n")
+
+	_, err := runPolicyCmd(t, newPolicyInstallCmd(), cand)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts")
+}
+
+func TestPolicyList_EmptyHostShowsBuiltinOnly(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+
+	out, err := runPolicyCmd(t, newPolicyListCmd())
+	require.NoError(t, err)
+	assert.Contains(t, out, "builtin")
+	assert.Contains(t, out, "Only built-in rules are active")
+}
+
+func TestPolicyList_BrokenFileDoesNotHideOthers(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	pdir := filepath.Join(gryphConfigDir(root), "policies")
+	writePolicyFile(t, filepath.Join(pdir, "good.yaml"), "version: \"1\"\nrules:\n  - id: g\n    action: allow\n")
+	writePolicyFile(t, filepath.Join(pdir, "bad.yaml"), "rules:\n  - id: \"\"\n    action: allow\n")
+
+	out, err := runPolicyCmd(t, newPolicyListCmd())
+	require.NoError(t, err)
+	assert.Contains(t, out, "good.yaml")
+	assert.Contains(t, out, "bad.yaml")
+	assert.Contains(t, out, "!")
+}

--- a/cli/policy_authoring_test.go
+++ b/cli/policy_authoring_test.go
@@ -184,6 +184,58 @@ func TestPolicyInstall_RefusesMergeConflict(t *testing.T) {
 	assert.Contains(t, err.Error(), "conflicts")
 }
 
+func TestInstallDestName(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		flag    string
+		want    string
+		wantErr bool
+	}{
+		{"basename with yaml", "/tmp/cand.yaml", "", "cand.yaml", false},
+		{"basename without extension normalizes", "/tmp/cand", "", "cand.yaml", false},
+		{"name flag normalizes", "/tmp/cand.yaml", "guard", "guard.yaml", false},
+		{"name flag keeps yml", "/tmp/cand.yaml", "guard.yml", "guard.yml", false},
+		{"name with separator rejected", "/tmp/cand.yaml", "sub/guard", "", true},
+		{"name with parent rejected", "/tmp/cand.yaml", "../guard", "", true},
+		{"name dotdot rejected", "/tmp/cand.yaml", "..", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := installDestName(tc.src, tc.flag)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPolicyInstall_RejectsPathName(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	cand := filepath.Join(t.TempDir(), "cand.yaml")
+	writePolicyFile(t, cand, "version: \"1\"\nrules:\n  - id: r\n    action: allow\n")
+
+	_, err := runPolicyCmd(t, newPolicyInstallCmd(), cand, "--name", "sub/guard")
+	require.Error(t, err)
+}
+
+func TestPolicyInit_WarnsOnMergedConflict(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+
+	_, err := runPolicyCmd(t, newPolicyInitCmd())
+	require.NoError(t, err)
+
+	out, err := runPolicyCmd(t, newPolicyInitCmd(), "guard")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Warning")
+	assert.Contains(t, out, "duplicate rule id")
+}
+
 func TestPolicyList_EmptyHostShowsBuiltinOnly(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", root)

--- a/cli/policy_authoring_test.go
+++ b/cli/policy_authoring_test.go
@@ -236,6 +236,26 @@ func TestPolicyInit_WarnsOnMergedConflict(t *testing.T) {
 	assert.Contains(t, out, "duplicate rule id")
 }
 
+func TestPolicyTest_FileFlag(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+
+	draft := filepath.Join(t.TempDir(), "draft.yaml")
+	writePolicyFile(t, draft, "version: \"1\"\nrules:\n  - id: draft-no-prod\n    action: block\n    match:\n      action_types: [file_write]\n      file_patterns: [\"**/prod/**\"]\n")
+
+	out, err := runPolicyCmd(t, newPolicyTestCmd(), "--file", draft, "--action", "file_write", "--path", "/app/prod/config.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, out, "BLOCK")
+	assert.Contains(t, out, "draft-no-prod")
+
+	out, err = runPolicyCmd(t, newPolicyTestCmd(), "--file", draft, "--action", "file_write", "--path", "/app/dev/config.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, out, "ALLOW")
+
+	_, err = runPolicyCmd(t, newPolicyTestCmd(), "--file", filepath.Join(t.TempDir(), "absent.yaml"), "--action", "file_write", "--path", "/x")
+	require.Error(t, err)
+}
+
 func TestPolicyList_EmptyHostShowsBuiltinOnly(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", root)

--- a/config/config.go
+++ b/config/config.go
@@ -415,6 +415,16 @@ func DefaultPolicyFilePath(paths *Paths) string {
 	return filepath.Join(paths.ConfigDir, "policy.yaml")
 }
 
+// DefaultPolicyDirPath returns the on-disk default for the policies directory.
+// Files in this directory merge after the global file and before the built-in
+// rules. The name is a fixed convention, not a settable path.
+func DefaultPolicyDirPath(paths *Paths) string {
+	if paths == nil {
+		paths = ResolvePaths()
+	}
+	return filepath.Join(paths.ConfigDir, "policies")
+}
+
 // ResolveReceiptKeyPath returns the configured signing-key path or the
 // platform default.
 func (c *Config) ResolveReceiptKeyPath(paths *Paths) string {

--- a/docs/aarm-dev.md
+++ b/docs/aarm-dev.md
@@ -53,7 +53,7 @@ write the execution outcome to the accumulator row and the receipt row.
 | `aarm/mediation` | `Adapter` interface plus `HookAdapter` and `MCPAdapter`. Normalizes agent events into `model.Action` and enriches with classify / injectscore / identity. |
 | `aarm/pdp` | Policy Decision Point. `Policy` / `Rule` schema, YAML parse, rule compile, `Evaluate`, CEL conditions, message templates, policy hash. |
 | `aarm/pep` | Policy Enforcement boundary. Maps `model.EvaluationResult` to `core/security.CheckResult`. |
-| `aarm/loader` | `Loader` merges policy `Source` values. `FileSource` and `BuiltinSource` (self-protection rules). |
+| `aarm/loader` | `Loader` merges policy `Source` values. `FileSource`, `DirSource` (the policies directory), and `BuiltinSource` (self-protection rules). |
 | `aarm/accumulator` | Context Accumulator interface. Per-session action memory feeding `context.*` CEL variables. `Nop` and SQLite implementations. |
 | `aarm/accumulator/contextchain` | Per-session hash chain over context-action rows. |
 | `aarm/receipt` | Append-only, hash-chained receipt log. Hashing, Ed25519 signing, chain verify, JSONL export, log verify. |
@@ -147,19 +147,42 @@ Conditions run under a 100 ms timeout and a CEL cost limit. `message` is a Go
 
 ## Loader and self-protection
 
+`buildPolicyLoader` in `cli/policy.go` resolves three sources in order: the
+global file `${ConfigDir}/policy.yaml` (`FileSource`), the directory
+`${ConfigDir}/policies/*.yaml` (`DirSource`, one document per file, sorted by
+name), and the built-in source. `policyLoaderSources` is the single definition
+of this order. Both user sources sit inside `${ConfigDir}`, so both are covered
+by the `${ConfigDir}/**` self-protection glob. No other location is resolved.
+
 `Loader.Load` merges sources in order. Rules:
 
 - Duplicate rule IDs across sources are a load error.
-- A user source's `disabled` list removes matching user rule IDs.
+- A document's `disabled` list removes only rules defined in the same document.
+  The scope is uniform for every source. A file cannot disable a rule from
+  another file. A `disabled` entry that names no rule in the same file logs a
+  warning and has no effect. A disabled rule does not reserve its ID, so another
+  file may define it.
 - `BuiltinSource` rules (self-protection) load last, use the reserved
-  `gryph-builtin-` ID prefix, and are never removed by a user `disabled` list.
-  A user rule may not use the reserved prefix.
+  `gryph-builtin-` ID prefix, and are never removed by a `disabled` list. A user
+  rule may not use the reserved prefix.
+
+The monotone precedence (block over allow) plus the same-file `disabled` scope
+make the policies directory additive: a file merged there can add rules but
+cannot lower the built-in floor or remove another file's rules. `gryph policy
+install` relies on this. See
+[security-policy-threat-model.md](./security-policy-threat-model.md).
 
 Self-protection blocks agent writes to Gryph's own control surfaces (policy,
 config, database, signing keys, agent hook configs). The operator toggles it
 only through `policy.self_protection.enabled`. Inspect the rules with
 `gryph policy builtin`. `selfProtectionGlobs` in `cli/policy.go` builds the
 globs.
+
+`gryph policy list` enumerates the sources with rule counts. `gryph policy
+install` promotes a reviewed candidate file into the policies directory. It
+validates the candidate alone, then validates the merged result, excluding the
+file it replaces. `gryph policy validate --file` and `edit <path>` validate one
+off-tree file in isolation.
 
 ## Receipts
 
@@ -215,8 +238,10 @@ counters.
 ## CLI surface
 
 `NewPolicyCmd` in `cli/policy.go` assembles the `gryph policy` tree: `init`,
-`edit`, `schema`, `builtin`, `validate`, `test`, `context`, `receipts`
-(`export`, `verify-log`), `approve`, `keys`, `deferrals`. Use
+`edit`, `list` (alias `ls`), `install`, `schema`, `builtin`, `validate`,
+`test`, `context`, `receipts` (`export`, `verify-log`), `approve`, `keys`,
+`deferrals`. `init` and `edit` take an optional name-or-path argument
+(`cli/policy.go`). `list` and `install` live in `cli/policy_authoring.go`. Use
 `gryph policy test` to dry-run a synthetic action through the merged policy
 without an agent event.
 

--- a/docs/aarm-dev.md
+++ b/docs/aarm-dev.md
@@ -167,8 +167,8 @@ by the `${ConfigDir}/**` self-protection glob. No other location is resolved.
   rule may not use the reserved prefix.
 
 A block always beats an allow. `disabled` acts only on one file. So the policies
-directory is additive. A file merged there can add rules. It cannot lower the
-built-in floor. It cannot remove another file's rules. `gryph policy install`
+directory is additive. A file merged there can add rules. It cannot remove the
+built-in rules or another file's rules. `gryph policy install`
 relies on this. See
 [security-policy-threat-model.md](./security-policy-threat-model.md).
 

--- a/docs/aarm-dev.md
+++ b/docs/aarm-dev.md
@@ -166,10 +166,10 @@ by the `${ConfigDir}/**` self-protection glob. No other location is resolved.
   `gryph-builtin-` ID prefix, and are never removed by a `disabled` list. A user
   rule may not use the reserved prefix.
 
-The monotone precedence (block over allow) plus the same-file `disabled` scope
-make the policies directory additive: a file merged there can add rules but
-cannot lower the built-in floor or remove another file's rules. `gryph policy
-install` relies on this. See
+A block always beats an allow. `disabled` acts only on one file. So the policies
+directory is additive. A file merged there can add rules. It cannot lower the
+built-in floor. It cannot remove another file's rules. `gryph policy install`
+relies on this. See
 [security-policy-threat-model.md](./security-policy-threat-model.md).
 
 Self-protection blocks agent writes to Gryph's own control surfaces (policy,

--- a/docs/aarm-dev.md
+++ b/docs/aarm-dev.md
@@ -182,7 +182,8 @@ globs.
 install` promotes a reviewed candidate file into the policies directory. It
 validates the candidate alone, then validates the merged result, excluding the
 file it replaces. `gryph policy validate --file` and `edit <path>` validate one
-off-tree file in isolation.
+off-tree file in isolation. `gryph policy test --file` dry-runs one off-tree file
+plus the built-in rules, so an author can check a draft before install.
 
 ## Receipts
 

--- a/docs/security-policy-threat-model.md
+++ b/docs/security-policy-threat-model.md
@@ -88,8 +88,7 @@ switch. The config file sits inside the protected config directory.
 `disabled:` acts only on the file that declares the rule. This matches the file
 an author or an agent edits. One installed file cannot remove a rule from another
 file. It cannot remove a rule from the operator's global file. An installed file
-only adds rules. This keeps the review step below simple. An installed file only
-adds.
+only adds rules. This keeps the review step below simple.
 
 ## The review step for candidate files
 

--- a/docs/security-policy-threat-model.md
+++ b/docs/security-policy-threat-model.md
@@ -1,0 +1,152 @@
+# Gryph Policy Threat Model
+
+This document states what the Gryph policy layer defends, how it combines
+policy, and where its limits are. Read it with the user guide in
+[security-policy.md](./security-policy.md).
+
+## What Gryph is
+
+Gryph applies a policy layer to AI coding agents. It mediates an agent's
+actions through hooks. It evaluates each action against a policy and returns a
+decision: allow, warn, guidance, defer, escalate, or block. It records a signed
+receipt for each mediated action.
+
+Gryph is a control on the agent. It is not a control on the host.
+
+## What Gryph does not defend
+
+Gryph runs as the same operating-system user as the agent. It assumes that
+user, the host, and the runtime are honest. Gryph does not defend against:
+
+- A compromised runtime or operating system.
+- A root adversary, or malware that runs as the same user with intent to
+  disable Gryph.
+- An agent that runs an arbitrary process as the same user to write files
+  directly, outside the mediated tool path.
+
+These are outside the trust boundary. The built-in self-protection rules raise
+the cost of a lazy tamper attack, but they are a same-user soft control. A
+determined same-user adversary can defeat them. The
+[hardened deployment](#genuine-gaps-and-hardened-deployment) section lists the
+lower-level controls that close these gaps.
+
+## Actors
+
+- **Operator.** The human who owns the host and authors policy. Trusted.
+- **Agent.** The AI coding agent. Untrusted with respect to policy. A
+  prompt-injected agent may try to weaken enforcement.
+- **Reviewer.** A human who promotes a candidate policy file into the active
+  set with `gryph policy install`. Trusted.
+
+## Policy resolution
+
+Policy resolves from three sources, in order: the global file
+`${ConfigDir}/policy.yaml`, the directory `${ConfigDir}/policies/*.yaml`, and
+the built-in self-protection rules. Both user sources sit inside the config
+directory. Gryph resolves no other location. A file at any other path is never
+loaded as policy.
+
+The config directory is protected by the built-in `gryph-builtin-protected-files`
+rule. An agent's mediated `file_write` or `file_delete` into it is blocked.
+
+## The combining model is monotone
+
+The engine evaluates every matching rule and keeps the highest-precedence
+decision:
+
+```
+block > escalate > defer > guidance > warn > allow
+```
+
+Two properties follow, and they are the core of the policy security argument:
+
+1. **An allow can never override a block.** `allow` is the lowest tier. A rule
+   that allows an action cannot lower a block from another rule. Order between
+   files does not change this. Precedence decides, not position.
+2. **Adding a rule can only raise a decision, never lower it.** A new file can
+   add a block, a warn, or an allow. Its allow cannot weaken an existing block.
+   So adding a policy file is non-weakening. The worst a bad additive file can
+   do is block too much. That fails in the safe direction, and it is visible in
+   `gryph policy list` and in receipts.
+
+The built-in rules load last and carry the top tier. No user rule can shadow
+them.
+
+## The built-in floor cannot be disabled
+
+`disabled:` removes rules. Two limits keep it from weakening the floor:
+
+- `disabled:` is scoped to the file that declares it. It removes only rules
+  defined in the same file. A file cannot disable a rule from another file.
+- A user file cannot name a built-in rule ID. The `gryph-builtin-` prefix is
+  reserved, and the built-in source is never subject to a `disabled:` list.
+
+The only switch for the built-in rules is `policy.self_protection.enabled` in
+the operator's config file. It is a coarse, all-or-nothing control. The config
+file is itself inside the protected config directory.
+
+## Same-file disabled scope
+
+`disabled:` reaches only the file that declares the rule. This matches the unit
+an author or an agent sees. It also keeps one installed file from removing a
+rule that another file, or the operator's global file, established. An installed
+file can add rules. It cannot subtract from what another file set. This makes
+the review gate below safe to reason about: a promoted file only adds.
+
+## The review gate for candidate files
+
+An agent can author a candidate policy file at an unprotected path with
+`gryph policy init <path>`. The file is a candidate. It is never resolved as
+policy. A human promotes a reviewed candidate into `${ConfigDir}/policies/`
+with `gryph policy install`.
+
+`install` validates the candidate alone, then validates the merged result that
+would follow the install, so a file that is valid on its own but breaks the
+merge (a duplicate rule ID across files, a reserved prefix) is refused before it
+is copied.
+
+The gate has a hard part and a soft part:
+
+- **Hard, by construction.** The agent's own file tools cannot write into
+  `${ConfigDir}/policies/`. The built-in file rule blocks the mediated write.
+- **Soft, same-user.** `gryph policy install` writes into the directory as the
+  Gryph process, not as a mediated tool call. An agent that can run shell
+  commands as the same user can run `install` itself. This shares the same-user
+  limit above. It is not closed by construction. Every `install` writes a
+  self-audit row, so a promote is at least visible after the fact.
+
+Because the combining model is monotone and `disabled:` is same-file scoped, a
+policy an agent manages to install can only add rules. It cannot lower the
+built-in floor and it cannot remove the operator's rules. The residual risk is
+over-blocking, which fails safe.
+
+## Genuine gaps and hardened deployment
+
+Gryph alone cannot close the same-user gaps. A hardened deployment adds a
+lower-level control, for example an EDR agent or a kernel mechanism, that
+protects Gryph's own surfaces.
+
+- **Policy Enforcement Point (the hooks).** The agent's hook configuration
+  lives in a user-writable location. A same-user process can edit it to remove
+  or redirect the Gryph hook, without touching policy. Gryph's self-protection
+  catches only the mediated write. A kernel or EDR control that protects the
+  hook configuration files closes this gap. Gryph cannot close it on its own.
+- **Policy Decision Point (the binary).** The decision runs in the user-side
+  `gryph` binary. A same-user adversary can patch it, shadow it earlier on
+  `PATH`, or preload code into it. The path is to install the `gryph` binary
+  under root ownership on a protected location, guarded by the same kernel or
+  EDR control that protects the hooks. One mechanism covers both the hooks and
+  the binary.
+
+With the hooks and the binary protected by a lower-level control, the same-user
+adversary can no longer unhook Gryph or forge a decision, and the policy files
+in the config directory gain the same protection. Until then, the honest
+statement is that Gryph raises the cost of tampering for a same-user adversary
+but does not stop a determined one.
+
+## Related hardening
+
+The receipt design lists further controls that raise the cost of tampering with
+the audit trail: anchor each session head to an external append-only log, move
+the signing key behind a platform keystore, and pin verifier public keys out of
+band. See the receipt sections of [security-policy.md](./security-policy.md).

--- a/docs/security-policy-threat-model.md
+++ b/docs/security-policy-threat-model.md
@@ -1,152 +1,151 @@
 # Gryph Policy Threat Model
 
-This document states what the Gryph policy layer defends, how it combines
-policy, and where its limits are. Read it with the user guide in
+This document states what the Gryph policy layer defends. It states how Gryph
+combines policy. It states the limits. Read it with the user guide in
 [security-policy.md](./security-policy.md).
 
 ## What Gryph is
 
-Gryph applies a policy layer to AI coding agents. It mediates an agent's
-actions through hooks. It evaluates each action against a policy and returns a
-decision: allow, warn, guidance, defer, escalate, or block. It records a signed
-receipt for each mediated action.
+Gryph applies a policy layer to AI coding agents. It mediates an agent's actions
+through hooks. It checks each action against a policy. It returns one decision:
+allow, warn, guidance, defer, escalate, or block. It writes a signed receipt for
+each mediated action.
 
 Gryph is a control on the agent. It is not a control on the host.
 
 ## What Gryph does not defend
 
-Gryph runs as the same operating-system user as the agent. It assumes that
-user, the host, and the runtime are honest. Gryph does not defend against:
+Gryph runs as the same operating-system user as the agent. Gryph trusts that
+user, the host, and the runtime. Gryph does not defend against:
 
 - A compromised runtime or operating system.
-- A root adversary, or malware that runs as the same user with intent to
-  disable Gryph.
-- An agent that runs an arbitrary process as the same user to write files
-  directly, outside the mediated tool path.
+- A root adversary. Malware that runs as the same user and tries to disable
+  Gryph.
+- An agent that runs any process as the same user to write files directly,
+  outside the mediated tool path.
 
-These are outside the trust boundary. The built-in self-protection rules raise
-the cost of a lazy tamper attack, but they are a same-user soft control. A
-determined same-user adversary can defeat them. The
-[hardened deployment](#genuine-gaps-and-hardened-deployment) section lists the
-lower-level controls that close these gaps.
+These are outside the trust boundary. The built-in self-protection rules make
+tampering harder. They are a same-user control. A determined same-user adversary
+can defeat them. The [hardened deployment](#genuine-gaps-and-hardened-deployment)
+section lists the lower-level controls that close these gaps.
 
 ## Actors
 
-- **Operator.** The human who owns the host and authors policy. Trusted.
-- **Agent.** The AI coding agent. Untrusted with respect to policy. A
-  prompt-injected agent may try to weaken enforcement.
-- **Reviewer.** A human who promotes a candidate policy file into the active
-  set with `gryph policy install`. Trusted.
+- **Operator.** The human who owns the host and writes policy. Trusted.
+- **Agent.** The AI coding agent. Not trusted to change policy. A prompt-injected
+  agent can try to weaken enforcement.
+- **Reviewer.** The human who installs a candidate policy file with `gryph policy
+  install`. Trusted.
 
 ## Policy resolution
 
-Policy resolves from three sources, in order: the global file
-`${ConfigDir}/policy.yaml`, the directory `${ConfigDir}/policies/*.yaml`, and
-the built-in self-protection rules. Both user sources sit inside the config
-directory. Gryph resolves no other location. A file at any other path is never
-loaded as policy.
+Gryph resolves policy from three sources, in order. The first is the global file
+`${ConfigDir}/policy.yaml`. The second is the directory
+`${ConfigDir}/policies/*.yaml`. The third is the built-in self-protection rules.
+Both user sources sit inside the config directory. Gryph resolves no other
+location. Gryph never loads a file at any other path as policy.
 
-The config directory is protected by the built-in `gryph-builtin-protected-files`
-rule. An agent's mediated `file_write` or `file_delete` into it is blocked.
+The built-in `gryph-builtin-protected-files` rule protects the config directory.
+It blocks an agent's mediated `file_write` or `file_delete` into that directory.
 
-## The combining model is monotone
+## How decisions combine
 
-The engine evaluates every matching rule and keeps the highest-precedence
-decision:
+The engine checks every rule that matches. It keeps the decision with the
+highest precedence:
 
 ```
 block > escalate > defer > guidance > warn > allow
 ```
 
-Two properties follow, and they are the core of the policy security argument:
+Two properties follow. Both keep policy safe.
 
-1. **An allow can never override a block.** `allow` is the lowest tier. A rule
-   that allows an action cannot lower a block from another rule. Order between
-   files does not change this. Precedence decides, not position.
-2. **Adding a rule can only raise a decision, never lower it.** A new file can
-   add a block, a warn, or an allow. Its allow cannot weaken an existing block.
-   So adding a policy file is non-weakening. The worst a bad additive file can
-   do is block too much. That fails in the safe direction, and it is visible in
-   `gryph policy list` and in receipts.
+1. **An allow can never override a block.** `allow` has the lowest precedence. An
+   allow rule cannot lower a block from another rule. The order of the files does
+   not change this. Precedence decides, not position.
+2. **A new rule can only raise a decision, never lower it.** A new file adds a
+   block, a warn, or an allow. Its allow cannot weaken a block from another file.
+   So a new policy file cannot weaken policy. A bad file can only block too much.
+   A block is the safe result. `gryph policy list` and the receipts show it.
 
-The built-in rules load last and carry the top tier. No user rule can shadow
-them.
+The built-in rules load last. They have the highest precedence. No user rule can
+override them.
 
 ## The built-in floor cannot be disabled
 
 `disabled:` removes rules. Two limits keep it from weakening the floor:
 
-- `disabled:` is scoped to the file that declares it. It removes only rules
-  defined in the same file. A file cannot disable a rule from another file.
+- `disabled:` acts only on the file that declares it. It removes only rules from
+  the same file. A file cannot disable a rule from another file.
 - A user file cannot name a built-in rule ID. The `gryph-builtin-` prefix is
-  reserved, and the built-in source is never subject to a `disabled:` list.
+  reserved. `disabled:` never acts on the built-in source.
 
-The only switch for the built-in rules is `policy.self_protection.enabled` in
-the operator's config file. It is a coarse, all-or-nothing control. The config
-file is itself inside the protected config directory.
+The operator turns the built-in rules off only with
+`policy.self_protection.enabled` in the config file. It is an all-or-nothing
+switch. The config file sits inside the protected config directory.
 
 ## Same-file disabled scope
 
-`disabled:` reaches only the file that declares the rule. This matches the unit
-an author or an agent sees. It also keeps one installed file from removing a
-rule that another file, or the operator's global file, established. An installed
-file can add rules. It cannot subtract from what another file set. This makes
-the review gate below safe to reason about: a promoted file only adds.
+`disabled:` acts only on the file that declares the rule. This matches the file
+an author or an agent edits. One installed file cannot remove a rule from another
+file. It cannot remove a rule from the operator's global file. An installed file
+only adds rules. This keeps the review step below simple. An installed file only
+adds.
 
-## The review gate for candidate files
+## The review step for candidate files
 
-An agent can author a candidate policy file at an unprotected path with
-`gryph policy init <path>`. The file is a candidate. It is never resolved as
-policy. A human promotes a reviewed candidate into `${ConfigDir}/policies/`
-with `gryph policy install`.
+An agent can write a candidate policy file at an unprotected path with `gryph
+policy init <path>`. The file is a candidate. Gryph never resolves it as policy.
+A human installs a reviewed candidate into `${ConfigDir}/policies/` with `gryph
+policy install`.
 
-`install` validates the candidate alone, then validates the merged result that
-would follow the install, so a file that is valid on its own but breaks the
-merge (a duplicate rule ID across files, a reserved prefix) is refused before it
-is copied.
+`install` first validates the candidate alone. Then it validates the merged
+result that would follow the install. A file can be valid alone but break the
+merge, for example with a duplicate rule ID or a reserved prefix. `install`
+refuses such a file before it copies it.
 
-The gate has a hard part and a soft part:
+The step has a hard part and a soft part:
 
-- **Hard, by construction.** The agent's own file tools cannot write into
+- **Hard, by design.** The agent's own file tools cannot write into
   `${ConfigDir}/policies/`. The built-in file rule blocks the mediated write.
 - **Soft, same-user.** `gryph policy install` writes into the directory as the
-  Gryph process, not as a mediated tool call. An agent that can run shell
-  commands as the same user can run `install` itself. This shares the same-user
-  limit above. It is not closed by construction. Every `install` writes a
-  self-audit row, so a promote is at least visible after the fact.
+  Gryph process. It is not a mediated tool call. An agent that runs shell
+  commands as the same user can run `install` itself. This is the same-user limit
+  from above. The design does not close it. Every `install` writes a self-audit
+  row. The install is visible after the fact.
 
-Because the combining model is monotone and `disabled:` is same-file scoped, a
-policy an agent manages to install can only add rules. It cannot lower the
-built-in floor and it cannot remove the operator's rules. The residual risk is
-over-blocking, which fails safe.
+A block always beats an allow. `disabled:` acts only on one file. So a policy
+that an agent installs can only add rules. It cannot lower the built-in floor. It
+cannot remove the operator's rules. The remaining risk is over-blocking. A block
+is the safe result.
 
 ## Genuine gaps and hardened deployment
 
 Gryph alone cannot close the same-user gaps. A hardened deployment adds a
-lower-level control, for example an EDR agent or a kernel mechanism, that
-protects Gryph's own surfaces.
+lower-level control that protects Gryph's own surfaces, for example an EDR agent
+or a kernel mechanism.
 
-- **Policy Enforcement Point (the hooks).** The agent's hook configuration
-  lives in a user-writable location. A same-user process can edit it to remove
-  or redirect the Gryph hook, without touching policy. Gryph's self-protection
-  catches only the mediated write. A kernel or EDR control that protects the
-  hook configuration files closes this gap. Gryph cannot close it on its own.
+- **Policy Enforcement Point (the hooks).** The agent's hook configuration sits
+  in a user-writable location. A same-user process can edit it to remove or
+  redirect the Gryph hook. It does not touch policy to do this. Gryph's
+  self-protection catches only the mediated write. A kernel or EDR control that
+  protects the hook configuration files closes this gap. Gryph cannot close it on
+  its own.
 - **Policy Decision Point (the binary).** The decision runs in the user-side
-  `gryph` binary. A same-user adversary can patch it, shadow it earlier on
-  `PATH`, or preload code into it. The path is to install the `gryph` binary
-  under root ownership on a protected location, guarded by the same kernel or
-  EDR control that protects the hooks. One mechanism covers both the hooks and
-  the binary.
+  `gryph` binary. A same-user adversary can patch the binary. It can put another
+  binary earlier on `PATH`. It can preload code into the binary. The fix is to
+  install the `gryph` binary under root ownership on a protected location. The
+  same kernel or EDR control that protects the hooks protects the binary. One
+  mechanism covers both the hooks and the binary.
 
-With the hooks and the binary protected by a lower-level control, the same-user
-adversary can no longer unhook Gryph or forge a decision, and the policy files
-in the config directory gain the same protection. Until then, the honest
-statement is that Gryph raises the cost of tampering for a same-user adversary
-but does not stop a determined one.
+A lower-level control that protects the hooks and the binary closes these gaps.
+The same-user adversary can no longer unhook Gryph. It can no longer change the
+decision. The policy files in the config directory get the same protection. Until
+then, Gryph makes tampering harder for a same-user adversary. It does not stop a
+determined one.
 
 ## Related hardening
 
-The receipt design lists further controls that raise the cost of tampering with
-the audit trail: anchor each session head to an external append-only log, move
-the signing key behind a platform keystore, and pin verifier public keys out of
-band. See the receipt sections of [security-policy.md](./security-policy.md).
+The receipt design lists more controls that make audit-trail tampering harder.
+Anchor each session head to an external append-only log. Move the signing key
+behind a platform keystore. Pin verifier public keys from a separate channel. See
+the receipt sections of [security-policy.md](./security-policy.md).

--- a/docs/security-policy-threat-model.md
+++ b/docs/security-policy-threat-model.md
@@ -1,150 +1,79 @@
 # Gryph Policy Threat Model
 
-This document states what the Gryph policy layer defends. It states how Gryph
-combines policy. It states the limits. Read it with the user guide in
+Gryph applies a policy layer to AI coding agents. It mediates each agent action
+through hooks and returns a decision: allow, warn, guidance, defer, escalate, or
+block. It writes a signed receipt for each mediated action. This document states
+what that layer defends and where its limits are. Read it with
 [security-policy.md](./security-policy.md).
 
-## What Gryph is
+## Trust boundary
 
-Gryph applies a policy layer to AI coding agents. It mediates an agent's actions
-through hooks. It checks each action against a policy. It returns one decision:
-allow, warn, guidance, defer, escalate, or block. It writes a signed receipt for
-each mediated action.
-
-Gryph is a control on the agent. It is not a control on the host.
-
-## What Gryph does not defend
-
-Gryph runs as the same operating-system user as the agent. Gryph trusts that
-user, the host, and the runtime. Gryph does not defend against:
+Gryph is a control on the agent, not on the host. It runs as the same
+operating-system user as the agent, and it trusts that user, the host, and the
+runtime. Gryph does not defend against:
 
 - A compromised runtime or operating system.
-- A root adversary. Malware that runs as the same user and tries to disable
-  Gryph.
+- A root adversary, or malware that runs as the same user to disable Gryph.
 - An agent that runs any process as the same user to write files directly,
   outside the mediated tool path.
 
-These are outside the trust boundary. The built-in self-protection rules make
-tampering harder. They are a same-user control. A determined same-user adversary
-can defeat them. The [hardened deployment](#genuine-gaps-and-hardened-deployment)
-section lists the lower-level controls that close these gaps.
+The built-in self-protection rules make tampering harder, but they are a
+same-user control. A determined same-user adversary can defeat them. The
+[gaps](#gaps-and-hardened-deployment) section lists the lower-level controls that
+close this.
 
-## Actors
+## How policy resolves and combines
 
-- **Operator.** The human who owns the host and writes policy. Trusted.
-- **Agent.** The AI coding agent. Not trusted to change policy. A prompt-injected
-  agent can try to weaken enforcement.
-- **Reviewer.** The human who installs a candidate policy file with `gryph policy
-  install`. Trusted.
+Gryph resolves policy from three sources: the global file
+`${ConfigDir}/policy.yaml`, the files in `${ConfigDir}/policies/`, and the
+built-in self-protection rules. Both user sources sit inside the config
+directory. Gryph loads no file at any other path.
 
-## Policy resolution
+The engine keeps the decision with the highest precedence:
+`block > escalate > defer > guidance > warn > allow`. Two properties follow:
 
-Gryph resolves policy from three sources, in order. The first is the global file
-`${ConfigDir}/policy.yaml`. The second is the directory
-`${ConfigDir}/policies/*.yaml`. The third is the built-in self-protection rules.
-Both user sources sit inside the config directory. Gryph resolves no other
-location. Gryph never loads a file at any other path as policy.
+- An allow can never override a block. Precedence decides, not file order.
+- A new file can only add rules. It cannot lower a decision another rule makes,
+  so it cannot weaken policy. The worst it can do is block too much, which is the
+  safe direction.
 
-The built-in `gryph-builtin-protected-files` rule protects the config directory.
-It blocks an agent's mediated `file_write` or `file_delete` into that directory.
+The built-in rules load last and always apply. No policy file can remove them: a
+user file may not use the reserved `gryph-builtin-` prefix, and `disabled:` acts
+only on rules in the file that declares it. The operator turns the built-in rules
+off only with `policy.self_protection.enabled` in the config file, an
+all-or-nothing switch.
 
-## How decisions combine
+## Candidate review
 
-The engine checks every rule that matches. It keeps the decision with the
-highest precedence:
+An agent cannot write into the config directory. The built-in file rule blocks
+its mediated `file_write` there. So an agent drafts a candidate at an unprotected
+path, and a human installs it with `gryph policy install`. This is the review
+gate.
 
-```
-block > escalate > defer > guidance > warn > allow
-```
+The gate is hard against the agent's file tools, but soft against a shell: an
+agent that runs commands as the same user can run `install` itself. This is the
+same-user limit above. Every install writes a self-audit row, so it is visible.
+Because a new file can only add rules, an installed file cannot remove the
+built-in rules or the operator's rules. The remaining risk is over-blocking, the
+safe direction.
 
-Two properties follow. Both keep policy safe.
-
-1. **An allow can never override a block.** `allow` has the lowest precedence. An
-   allow rule cannot lower a block from another rule. The order of the files does
-   not change this. Precedence decides, not position.
-2. **A new rule can only raise a decision, never lower it.** A new file adds a
-   block, a warn, or an allow. Its allow cannot weaken a block from another file.
-   So a new policy file cannot weaken policy. A bad file can only block too much.
-   A block is the safe result. `gryph policy list` and the receipts show it.
-
-The built-in rules load last. They have the highest precedence. No user rule can
-override them.
-
-## The built-in floor cannot be disabled
-
-`disabled:` removes rules. Two limits keep it from weakening the floor:
-
-- `disabled:` acts only on the file that declares it. It removes only rules from
-  the same file. A file cannot disable a rule from another file.
-- A user file cannot name a built-in rule ID. The `gryph-builtin-` prefix is
-  reserved. `disabled:` never acts on the built-in source.
-
-The operator turns the built-in rules off only with
-`policy.self_protection.enabled` in the config file. It is an all-or-nothing
-switch. The config file sits inside the protected config directory.
-
-## Same-file disabled scope
-
-`disabled:` acts only on the file that declares the rule. This matches the file
-an author or an agent edits. One installed file cannot remove a rule from another
-file. It cannot remove a rule from the operator's global file. An installed file
-only adds rules. This keeps the review step below simple.
-
-## The review step for candidate files
-
-An agent can write a candidate policy file at an unprotected path with `gryph
-policy init <path>`. The file is a candidate. Gryph never resolves it as policy.
-A human installs a reviewed candidate into `${ConfigDir}/policies/` with `gryph
-policy install`.
-
-`install` first validates the candidate alone. Then it validates the merged
-result that would follow the install. A file can be valid alone but break the
-merge, for example with a duplicate rule ID or a reserved prefix. `install`
-refuses such a file before it copies it.
-
-The step has a hard part and a soft part:
-
-- **Hard, by design.** The agent's own file tools cannot write into
-  `${ConfigDir}/policies/`. The built-in file rule blocks the mediated write.
-- **Soft, same-user.** `gryph policy install` writes into the directory as the
-  Gryph process. It is not a mediated tool call. An agent that runs shell
-  commands as the same user can run `install` itself. This is the same-user limit
-  from above. The design does not close it. Every `install` writes a self-audit
-  row. The install is visible after the fact.
-
-A block always beats an allow. `disabled:` acts only on one file. So a policy
-that an agent installs can only add rules. It cannot lower the built-in floor. It
-cannot remove the operator's rules. The remaining risk is over-blocking. A block
-is the safe result.
-
-## Genuine gaps and hardened deployment
+## Gaps and hardened deployment
 
 Gryph alone cannot close the same-user gaps. A hardened deployment adds a
-lower-level control that protects Gryph's own surfaces, for example an EDR agent
-or a kernel mechanism.
+lower-level control, for example an EDR agent or a kernel mechanism, to protect
+two surfaces:
 
-- **Policy Enforcement Point (the hooks).** The agent's hook configuration sits
-  in a user-writable location. A same-user process can edit it to remove or
-  redirect the Gryph hook. It does not touch policy to do this. Gryph's
-  self-protection catches only the mediated write. A kernel or EDR control that
-  protects the hook configuration files closes this gap. Gryph cannot close it on
-  its own.
-- **Policy Decision Point (the binary).** The decision runs in the user-side
-  `gryph` binary. A same-user adversary can patch the binary. It can put another
-  binary earlier on `PATH`. It can preload code into the binary. The fix is to
-  install the `gryph` binary under root ownership on a protected location. The
-  same kernel or EDR control that protects the hooks protects the binary. One
-  mechanism covers both the hooks and the binary.
+- The hooks, which are the enforcement point. The agent's hook configuration sits
+  in a user-writable location. A same-user process can edit it to unhook Gryph,
+  without touching policy.
+- The binary, which is the decision point. The decision runs in the user-side
+  `gryph` binary. A same-user adversary can patch it, put another binary earlier
+  on `PATH`, or preload code. Install the binary under root ownership on a
+  protected path.
 
-A lower-level control that protects the hooks and the binary closes these gaps.
-The same-user adversary can no longer unhook Gryph. It can no longer change the
-decision. The policy files in the config directory get the same protection. Until
-then, Gryph makes tampering harder for a same-user adversary. It does not stop a
-determined one.
+The same lower-level control protects both surfaces, and the config-directory
+policy files gain the same protection. Until then, Gryph makes tampering harder
+for a same-user adversary, but does not stop a determined one.
 
-## Related hardening
-
-The receipt design lists more controls that make audit-trail tampering harder.
-Anchor each session head to an external append-only log. Move the signing key
-behind a platform keystore. Pin verifier public keys from a separate channel. See
-the receipt sections of [security-policy.md](./security-policy.md).
+The receipt design lists further controls against audit-trail tampering. See the
+receipt sections of [security-policy.md](./security-policy.md).

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -172,7 +172,7 @@ block > escalate > defer > guidance > warn > allow
 | `gryph policy install <path> [--name N] [--force] [--dry-run]` | Validate a candidate file, then copy it into the policies directory so it becomes active. The destination name is the source basename, or `<name>.yaml` with `--name`. Refuses to overwrite without `--force`. `--dry-run` validates and shows the destination without copying. |
 | `gryph policy schema` | Print the JSON Schema. Pipe into editor tooling or an AI agent. |
 | `gryph policy validate [--file PATH]` | Parse and compile the merged policy, reporting the rule count and sources. With `--file`, validate one file in isolation, without merging the active policy. Use `--file` to lint a candidate before install. |
-| `gryph policy test ...` | Dry-run a synthetic action through the merged policy. See `--help` for flags. |
+| `gryph policy test ...` | Dry-run a synthetic action through the merged policy. With `--file PATH`, dry-run against one file plus the built-in rules, to check a draft before install. See `--help` for flags. |
 
 `gryph policy test` accepts `--format json` for machine-readable output.
 
@@ -205,6 +205,8 @@ Do these steps each time you change a policy file.
    gryph policy test --action command_exec --command "rm -rf /"
    gryph policy test --action file_write --path /app/prod/config.yaml
    ```
+
+   Add `--file <path>` to dry-run a draft file plus the built-in rules, before you install it.
 
    Test three cases per rule: an action that must match, an action that must not match, and an action near the boundary of the rule.
 

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -28,16 +28,22 @@ Once enabled, every supported agent hook runs through the engine.
 
 ## Where policy files live
 
-Gryph loads policy from exactly two sources, in this order:
+Gryph loads policy from three sources, in this order:
 
-1. **Global policy file** (`${ConfigDir}/policy.yaml`, optional). The single operator-owned file. On macOS this is `~/Library/Application Support/gryph/policy.yaml`; on Linux `~/.config/gryph/policy.yaml`. A missing file is not an error: with `policy.enabled: true` and no `policy.yaml` on disk, the merged policy contains built-in self-protection rules only.
-2. **Built-in self-protection rules** (always appended, never filtered). These protect the config directory, the database, and agent hook configs from agent self-modification.
+1. **Global policy file** (`${ConfigDir}/policy.yaml`, optional). The single operator-owned file. On macOS this is `~/Library/Application Support/gryph/policy.yaml`; on Linux `~/.config/gryph/policy.yaml`. A missing file is not an error.
+2. **Policies directory** (`${ConfigDir}/policies/*.yaml` and `*.yml`, optional). Each file is a separate policy document. Files load in sorted name order and merge after the global file. A missing directory is not an error. This lets you author policy as many small, self-contained files instead of one large file.
+3. **Built-in self-protection rules** (always appended, never filtered). These protect the config directory, the database, and agent hook configs from agent self-modification.
 
-Write the global file with `gryph policy init` (non-interactive, honors `--force` to overwrite) or open it in your editor with `gryph policy edit` (scaffolds from the built-in example when the file is missing, then runs validation after save). Per-project policy overlays are a planned future iteration; today, one host-global policy governs every project and agent on the host.
+With `policy.enabled: true` and no user files on disk, the merged policy contains built-in self-protection rules only.
 
-Use `disabled:` in the global file to suppress a built-in rule by ID. Rule IDs must be unique within the file; user rules may not use the `gryph-builtin-` prefix.
+Both the global file and the policies directory sit inside `${ConfigDir}`, so both are protected by the built-in self-protection rules. Gryph resolves no other location. A file at any other path is never loaded as policy.
+
+Write a file with `gryph policy init [name|path]` or open one with `gryph policy edit [name|path]`. See [Commands](#commands). Run `gryph policy list` to see every active source. Per-host managed policy is a planned future iteration; today, one host governs its own policy.
+
+Use `disabled:` to suppress a rule by ID. `disabled:` is scoped to the file that declares it. It removes only rules defined in the same file. A file cannot disable a rule from another file, and no user file can disable a built-in rule. Rule IDs must be unique across all files; user rules may not use the `gryph-builtin-` prefix. Namespace your rule IDs by the file's purpose to avoid collisions.
 
 ```yaml
+# in the same file that defines block-rm-rf-root
 disabled:
   - block-rm-rf-root
 ```
@@ -160,13 +166,26 @@ block > escalate > defer > guidance > warn > allow
 
 | Command | Purpose |
 |---|---|
-| `gryph policy init` | Write the fully documented example policy to `${ConfigDir}/policy.yaml`. Use `--force` to overwrite an existing file. |
-| `gryph policy edit` | Open the global policy in `$EDITOR`. Scaffolds from the built-in example when the file is missing. Runs validation after save. |
+| `gryph policy init [name\|path]` | Write the fully documented example policy to a target. No argument targets `${ConfigDir}/policy.yaml`. A bare name targets `<name>.yaml` in the policies directory. A path targets that literal file, a candidate for review and install. Use `--force` to overwrite. |
+| `gryph policy edit [name\|path]` | Open a policy file in `$EDITOR`. Same target rules as `init`. Scaffolds from the example when the file is missing. A name or the global file validates the merged policy after save. A path validates that file alone. |
+| `gryph policy list` (alias `ls`) | List every active source (global file, each policies file, built-ins) with its rule count. A broken file shows an error marker and does not hide the rest. The last line reports the merged total or a conflict. |
+| `gryph policy install <path> [--name N] [--force] [--dry-run]` | Validate a candidate file, then copy it into the policies directory so it becomes active. The destination name is the source basename, or `<name>.yaml` with `--name`. Refuses to overwrite without `--force`. `--dry-run` validates and shows the destination without copying. |
 | `gryph policy schema` | Print the JSON Schema. Pipe into editor tooling or an AI agent. |
-| `gryph policy validate` | Parse and compile the global policy. Reports rule count and the resolved file path. |
+| `gryph policy validate [--file PATH]` | Parse and compile the merged policy, reporting the rule count and sources. With `--file`, validate one file in isolation, without merging the active policy. Use `--file` to lint a candidate before install. |
 | `gryph policy test ...` | Dry-run a synthetic action through the merged policy. See `--help` for flags. |
 
 `gryph policy test` accepts `--format json` for machine-readable output.
+
+An agent authors a candidate, then a human promotes it:
+
+```
+agent$ gryph policy init ./candidate.yml           # write to an unprotected path
+agent$ $EDITOR ./candidate.yml                      # edit the candidate
+agent$ gryph policy validate --file ./candidate.yml # lint it
+human$ gryph policy install ./candidate.yml         # the human review gate
+```
+
+An agent cannot write into `${ConfigDir}/policies/` with its file tools, because the self-protection rules block it. Only a human-run `install` (or a plain copy) places a file there. See the [threat model](./security-policy-threat-model.md) for the limits of this control.
 
 ### Runtime inspection
 

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -38,9 +38,9 @@ With `policy.enabled: true` and no user files on disk, the merged policy contain
 
 Both the global file and the policies directory sit inside `${ConfigDir}`, so both are protected by the built-in self-protection rules. Gryph resolves no other location. A file at any other path is never loaded as policy.
 
-Write a file with `gryph policy init [name|path]` or open one with `gryph policy edit [name|path]`. See [Commands](#commands). Run `gryph policy list` to see every active source. Per-host managed policy is a planned future iteration; today, one host governs its own policy.
+Write a file with `gryph policy init [name|path]` or open one with `gryph policy edit [name|path]`. See [Commands](#commands). Run `gryph policy list` to see every active source. Per-host managed policy is a planned future iteration. Today, one host governs its own policy.
 
-Use `disabled:` to suppress a rule by ID. `disabled:` is scoped to the file that declares it. It removes only rules defined in the same file. A file cannot disable a rule from another file, and no user file can disable a built-in rule. Rule IDs must be unique across all files; user rules may not use the `gryph-builtin-` prefix. Namespace your rule IDs by the file's purpose to avoid collisions.
+Use `disabled:` to suppress a rule by ID. `disabled:` is scoped to the file that declares it. It removes only rules defined in the same file. A file cannot disable a rule from another file, and no user file can disable a built-in rule. Rule IDs must be unique across all files. User rules may not use the `gryph-builtin-` prefix. Namespace your rule IDs by the file's purpose to avoid collisions.
 
 ```yaml
 # in the same file that defines block-rm-rf-root

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -187,6 +187,56 @@ human$ gryph policy install ./candidate.yml         # the human review gate
 
 An agent cannot write into `${ConfigDir}/policies/` with its file tools, because the self-protection rules block it. Only a human-run `install` (or a plain copy) places a file there. See the [threat model](./security-policy-threat-model.md) for the limits of this control.
 
+## Verifying a policy
+
+Do these steps each time you change a policy file.
+
+1. Check the syntax.
+
+   ```bash
+   gryph policy validate
+   ```
+
+   Fix all errors before you continue. `gryph policy edit` runs this automatically when you save a named or global file. Use `gryph policy validate --file <path>` to check a candidate before install.
+
+2. Test each rule with a synthetic action. `gryph policy test` does not touch the database and does not run an agent.
+
+   ```bash
+   gryph policy test --action command_exec --command "rm -rf /"
+   gryph policy test --action file_write --path /app/prod/config.yaml
+   ```
+
+   Test three cases per rule: an action that must match, an action that must not match, and an action near the boundary of the rule.
+
+3. Test with a real agent. Start a session with a hooked agent, do an action that matches your rule, and check that the agent receives the correct block or guidance message.
+
+   WARNING: Keep `policy.fail_mode: closed` during tests. A broken policy then blocks actions instead of allowing them silently. If this locks you out, set `fail_mode: open` temporarily, fix the policy, and set it back.
+
+4. Check the receipts.
+
+   ```bash
+   gryph policy receipts --decision block
+   gryph policy receipts --verify --all-sessions
+   ```
+
+5. Check the context accumulator if your rule uses `context.*` variables. The counters shown here are the same values the CEL conditions see.
+
+   ```bash
+   gryph policy context --session <id|prefix>
+   gryph policy context --verify --session <id|prefix>
+   ```
+
+### Authoring safety rules
+
+1. Always run `gryph policy validate` before you use a policy.
+2. Always test a new rule with `gryph policy test` before you test with a real agent.
+3. Start new rules with `action: warn` or `enabled: false`. Change to `block` after you check the receipts.
+4. Do not use `fail_mode: open` in production.
+5. Keep `self_protection` enabled. It stops an agent from changing its own controls.
+6. Make `command_patterns` as narrow as possible. Wide patterns cause false blocks.
+7. Give each rule a clear `message`. The agent reads this text and changes its behavior.
+8. Namespace rule IDs by the file's purpose. IDs must be unique across every policy file.
+
 ### Runtime inspection
 
 | Command | Purpose |
@@ -195,7 +245,7 @@ An agent cannot write into `${ConfigDir}/policies/` with its file tools, because
 | `gryph policy receipts` | List receipt rows for mediated actions. `--session`, `--decision`, `--since`, `--until` filter. Pass `--show-hash` to include the per-row hash. |
 | `gryph policy receipts --verify` | Recompute the hash chain and verify any signatures. `--session ID` verifies one chain in full; `--all-sessions` verifies every chain. Exits non-zero on break or invalid signature. |
 | `gryph policy receipts export` | Stream receipts as JSONL or CSV. `--include-signatures` adds the Ed25519 signature columns. |
-| `gryph policy receipts verify-log --input FILE` | Verify an exported chain stand-alone. No database access needed. Verifies signatures when `--trust-store` resolves to a populated store. |
+| `gryph policy receipts verify-log --input FILE` | Verify an exported chain stand-alone. No database access needed. Verifies signatures when `--trust-store` resolves to a populated store. NOTE: `verify-log` reads a file, not the database. Run `gryph policy receipts export --include-signatures` first, or pipe: `gryph policy receipts export --include-signatures \| gryph policy receipts verify-log --input -`. |
 | `gryph policy approve list` | List pending approval requests. CLI prompts run in-process, so this is always empty in the CLI frontend. |
 | `gryph policy approve history` | Show receipts whose decision was `escalate`, `approved`, `denied`, or `approval_timeout`. |
 | `gryph policy deferrals` | List the pending-deferral queue. `--status` filters to `pending`, `resolved_allow`, `resolved_deny`, `resolved_timeout`, or `all`. `--session ID` scopes to one session. |
@@ -476,10 +526,16 @@ The default (`fail_open: false`) keeps AARM conformance.
 
 ## Troubleshooting
 
-- **Rule never matches.** Confirm the global policy file is present and valid with `gryph policy validate`, which also prints the resolved file path. Then `gryph policy test --action <type> --path <path>` and inspect the matched-rule output.
-- **Policy fails to load.** `gryph policy validate` reports the first compile error with the rule ID and line.
-- **Policy is enabled but nothing is blocked.** Confirm `policy.enabled: true` and that the agent in question is registered. Check `gryph query --status blocked` to see what was caught.
-- **I want to override a rule for one project.** Per-project policy overlays are a planned future iteration. Today, edit the global policy (`gryph policy edit`) and use `disabled: [rule-id]` or tighten the rule's `scope` field to exclude the project you want to exempt.
+| Problem | Cause | Solution |
+|---|---|---|
+| Rule never matches | Wrong `action_types` or pattern | Run `gryph policy validate` to confirm the file is present and valid (it prints the resolved path). Then `gryph policy test --action <type> --path <path>` and inspect the matched-rule output. |
+| Policy fails to load | Syntax or compile error | `gryph policy validate` reports the first compile error with the rule ID and line. Run `gryph policy list` to see which file is broken. |
+| All actions are blocked | `fail_mode: closed` and the policy has an error | Run `gryph policy validate` and fix the error. Set `fail_mode: open` temporarily if you are locked out. |
+| Policy is enabled but nothing is blocked | Layer disabled or agent not registered | Confirm `policy.enabled: true` and that the agent in question is registered. Check `gryph query --status blocked` to see what was caught. |
+| Receipts are unsigned | No key in the keys directory | Run `gryph policy keys generate`. Check `gryph policy keys list`. |
+| Duplicate rule ID error | Two rules use the same `id`, possibly in different files | Give each rule a unique ID. Namespace IDs by the file's purpose. |
+| `verify-log` asks for `--input` | The command reads a file, not the database | Run `gryph policy receipts export --include-signatures` first. |
+| Override a rule for one project | Per-project overlays are not supported yet | Tighten the rule's `scope` (agents, projects, tools) to exclude the project. To turn a rule off, add `disabled: [rule-id]` in the file that defines the rule. |
 
 <details>
 <summary><strong>Threat model: receipt keys and trust</strong></summary>


### PR DESCRIPTION
## Summary

This PR adds policy authoring and management commands to Gryph, enabling operators to author policy as multiple files in a policies directory instead of a single global file. It introduces `gryph policy list` to inspect active policies, `gryph policy install` to promote candidate files into the active set with validation, and extends `gryph policy init` and `gryph policy edit` to work with named files and candidate paths.

## Key Changes

**New CLI Commands:**
- `gryph policy list`: Lists all active policy sources (global file, policies directory, built-ins) with rule counts and merge status. Broken files are shown with error markers without hiding others.
- `gryph policy install <path>`: Validates a candidate policy file and copies it into the policies directory. Refuses to overwrite without `--force`. Validates both the candidate alone and the merged result to catch conflicts before install. Supports `--name` to customize the destination filename and `--dry-run` to preview without copying.

**Extended Commands:**
- `gryph policy init [name|path]`: Now accepts an optional argument. No argument targets the global file (existing behavior). A bare name targets `<name>.yaml` in the policies directory. A path targets that literal file as a candidate for review and install.
- `gryph policy edit [name|path]`: Now accepts an optional argument with the same resolution logic. Validates the merged policy for named/global targets, but validates the file alone for candidate paths.

**Policy Loading Architecture:**
- Added `DirSource` to load all YAML files from the policies directory in sorted order, enabling deterministic multi-file merges.
- Added `PolicyFilesInDir()` helper for consistent directory scanning across list, install, and loader.
- Added `NormalizePolicyFileName()` to normalize bare names to `.yaml` extension, so "guard" and "guard.yaml" resolve to the same file.

**Disabled Scope Refinement:**
- Changed `disabled:` semantics to be scoped to the file that declares it. A file can only disable rules it defines; it cannot disable rules from other files. This prevents one installed file from removing rules another file established.
- Added `warnUnmatchedDisabled()` to log warnings when a `disabled:` entry doesn't match any rule in its file.

**Self-Audit Integration:**
- Policy authoring actions (`policy_init`, `policy_edit`, `policy_install`) on managed files (global or policies directory) are recorded in the self-audit log as `config_change` actions.
- Added `auditPolicyChange()` and `openAuditStore()` helpers for best-effort audit logging that doesn't block authoring if the database is unavailable.

**Validation and Conflict Detection:**
- `checkMergedWithCandidate()` validates that a candidate file merges cleanly with the active policy before install, catching duplicate rule IDs and reserved prefix violations early.
- `copyPolicyFile()` handles file I/O with proper directory creation.

**Documentation:**
- Added `docs/security-policy-threat-model.md` explaining the policy layer's threat model, combining model (monotone precedence), review gate for candidates, and same-user limitations.
- Updated `docs/security-policy.md` to document the policies directory as a second source between the global file and built-ins.
- Updated `docs/aarm-dev.md` to reflect `DirSource` in the loader architecture.

**Testing:**
- Added comprehensive tests in `cli/policy_authoring_test.go` covering target resolution, init/edit/install lifecycle, merge conflict detection, and list output.
- Added loader tests for disabled scope, directory loading, and multi-file merges.

## Notable Implementation Details

- **Monotone combining model preserved:** The loader's precedence (block > escalate > defer > guidance > warn > allow) ensures an allow can never override a block, and adding a policy file can only raise decisions, never lower them.
- **Built-in floor cannot be weakened:** Built-in rules load last and are never subject to `disabled:` entries. The `gryph-builtin-` prefix is reserved for built-ins.
- **Review gate by construction:** The agent's mediated file tools cannot write into the policies directory (blocked by built

https://claude.ai/code/session_01NeKJcAPWmRb8rBRBSfxkvA