### PR TITLE
Add real-binary acceptance suite with guarantee catalog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,21 @@ jobs:
       - name: Verify JSON Schema is up-to-date
         run: make verify-schema
 
+  acceptance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run Acceptance Suite
+        run: go test -tags acceptance -v ./test/acceptance/
+
   goreleaser-test:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,31 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
+
       - name: Run Acceptance Suite
-        run: go test -tags acceptance -v ./test/acceptance/
+        run: |
+          gotestsum --junitfile "${RUNNER_TEMP}/acceptance.xml" --format testname \
+            -- -tags acceptance -timeout 10m ./test/acceptance
+
+      - name: Render Report
+        if: always()
+        run: |
+          go run ./test/acceptance/report \
+            -junit "${RUNNER_TEMP}/acceptance.xml" \
+            -catalog test/acceptance/catalog.yaml \
+            -scripts test/acceptance/scripts \
+            | tee "${RUNNER_TEMP}/acceptance-report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: acceptance-report
+          path: |
+            ${{ runner.temp }}/acceptance-report.md
+            ${{ runner.temp }}/acceptance.xml
 
   goreleaser-test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,18 @@ tui/            Output formatters (table, json, csv)
 - Sessions are created on first event and updated on subsequent events
 - Session end detected from `SessionEnd` (Claude Code) or `stop` (Cursor) hook types
 
+## Acceptance Suite
+
+- `test/acceptance/` runs the real `gryph` binary through `testscript` txtar scripts in a
+  sandboxed HOME. It gates CI on every PR and push. It owns the real-binary contracts: exit
+  codes, on-disk file shapes, stdout and stderr formats, hook protocol responses.
+- A user-facing guarantee needs a `<category>/.../<name>.txtar` script AND a matching
+  `catalog.yaml` row (with a `tier`, and optional `labels`). `TestCatalogIntegrity` (runs
+  under `go test ./...`) fails when a script has no catalog row. Do not add scaffolding.
+  See `test/acceptance/README.md`.
+- `test/cli/` (in-process pipeline tests) and `test/conformance/aarm/` (AARM spec) stay
+  separate and do not overlap with the acceptance suite.
+
 ## Dev Docs
 
 - `docs/e2e.md` - Writing and running E2E tests (`test/cli/`)

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ gryph query --action exec --since "1w"           # Commands run in the last week
 gryph query --session abc123                             # Activity from a specific session
 gryph query --action file_write --today --count          # Count matching events
 gryph query --command "npm *" --since "1w"               # Filter by command pattern
-gryph query --action file_write --show-diff              # Include file diffs
 ```
 
 ### Sessions

--- a/aarm/receipt/hash.go
+++ b/aarm/receipt/hash.go
@@ -30,7 +30,7 @@
 //  11. decision           (utf-8 bytes)
 //  12. severity           (utf-8 bytes)
 //  13. message            (utf-8 bytes)
-//  14. matched_rule_ids   (canonical JSON of []string, "null" when empty)
+//  14. matched_rule_ids   (canonical JSON of []string, "null" when nil or empty; NewHashInput normalizes)
 //  15. result_status      (utf-8 bytes)
 //  16. duration_ms        (int64, 8 bytes BE; 0 when unset)
 //  17. error_message      (utf-8 bytes)
@@ -203,6 +203,15 @@ type HashInputFields struct {
 // emptied. Single source of truth for the as-recorded hash input shape.
 func NewHashInput(f HashInputFields) *HashInput {
 	insertDecision := DeriveInsertDecision(f.Decision)
+	// The consensus format hashes matched_rule_ids as "null" when the list is
+	// empty. The PDP hands an empty non-nil slice for a no-match decision,
+	// which would serialize as "[]", while storage persists it as NULL and a
+	// re-read hands back nil. Normalizing here keeps insert-time and
+	// verify-time hash inputs identical for every path.
+	ruleIDs := f.MatchedRuleIDs
+	if len(ruleIDs) == 0 {
+		ruleIDs = nil
+	}
 	return &HashInput{
 		Sequence:           f.Sequence,
 		PrevHash:           f.PrevHash,
@@ -217,7 +226,7 @@ func NewHashInput(f HashInputFields) *HashInput {
 		Decision:           insertDecision,
 		Severity:           f.Severity,
 		Message:            f.Message,
-		MatchedRuleIDs:     f.MatchedRuleIDs,
+		MatchedRuleIDs:     ruleIDs,
 		ResultStatus:       DeriveInsertResultStatus(insertDecision),
 		DurationMS:         0,
 		ErrorMessage:       "",

--- a/aarm/receipt/hash_test.go
+++ b/aarm/receipt/hash_test.go
@@ -1,0 +1,44 @@
+package receipt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The consensus format hashes matched_rule_ids as "null" when the list is
+// empty. The PDP produces an empty non-nil slice for a no-match decision,
+// while storage returns nil for the same row. Both must hash identically or
+// every allow receipt breaks chain verification after a DB or export round
+// trip.
+func TestNewHashInputNormalizesEmptyMatchedRuleIDs(t *testing.T) {
+	base := HashInputFields{
+		Sequence:       1,
+		RecordedAtUnix: time.Date(2026, time.May, 16, 12, 0, 0, 0, time.UTC).UnixNano(),
+		SessionID:      uuid.MustParse("2fad3402-a209-56c0-8c76-25256098cf39"),
+		Agent:          "claude-code",
+		Tool:           "Read",
+		ActionType:     "file_read",
+		Decision:       "allow",
+	}
+
+	withNil := base
+	withNil.MatchedRuleIDs = nil
+	withEmpty := base
+	withEmpty.MatchedRuleIDs = []string{}
+	withRule := base
+	withRule.MatchedRuleIDs = []string{"r-1"}
+
+	hashNil, err := ComputeHash(NewHashInput(withNil))
+	require.NoError(t, err)
+	hashEmpty, err := ComputeHash(NewHashInput(withEmpty))
+	require.NoError(t, err)
+	hashRule, err := ComputeHash(NewHashInput(withRule))
+	require.NoError(t, err)
+
+	assert.Equal(t, hashNil, hashEmpty, "nil and empty matched_rule_ids must hash identically")
+	assert.NotEqual(t, hashNil, hashRule, "a matched rule must change the hash")
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -89,6 +89,7 @@ gryph logs --format json
 | Flag         | Short | Type     | Default | Description                                        |
 | ------------ | ----- | -------- | ------- | -------------------------------------------------- |
 | `--follow`   | `-f`  | bool     | false   | Stream new events                                  |
+| `--live`     |       | bool     | false   | Interactive full-screen TUI monitor                |
 | `--interval` |       | duration | 2s      | Poll interval for follow mode                      |
 | `--since`    |       | string   |         | Show events since (e.g., `1h`, `2d`, `2025-01-15`) |
 | `--until`    |       | string   |         | Show events until                                  |
@@ -97,6 +98,7 @@ gryph logs --format json
 | `--session`  |       | string   |         | Filter by session ID                               |
 | `--agent`    |       | string   |         | Filter by agent                                    |
 | `--format`   |       | string   | table   | Output format: `table`, `json`, `jsonl`            |
+| `--sort`     |       | string   | desc    | Sort order: `asc`, `desc`                          |
 
 ### query
 
@@ -107,27 +109,29 @@ gryph query --file "src/**/*.ts"
 gryph query --since "1w" --agent claude-code
 gryph query --action file_write --today
 gryph query --command "npm *"
-gryph query --action file_write --show-diff
 gryph query --action file_write --today --count
+gryph query --interactive
 ```
 
-| Flag          | Type                | Default | Description                                    |
-| ------------- | ------------------- | ------- | ---------------------------------------------- |
-| `--since`     | string              |         | Start time                                     |
-| `--until`     | string              |         | End time                                       |
-| `--today`     | bool                | false   | Filter to today                                |
-| `--yesterday` | bool                | false   | Filter to yesterday                            |
-| `--agent`     | string (repeatable) |         | Filter by agent                                |
-| `--session`   | string              |         | Filter by session ID (prefix match)            |
-| `--action`    | string (repeatable) |         | Filter by action type                          |
-| `--file`      | string              |         | Filter by file path (glob)                     |
-| `--command`   | string              |         | Filter by command (glob)                       |
-| `--status`    | string              |         | Filter by result status                        |
-| `--show-diff` | bool                | false   | Include diff content in output                 |
-| `--format`    | string              | table   | Output format: `table`, `json`, `jsonl`, `csv` |
-| `--limit`     | int                 | 100     | Maximum results                                |
-| `--offset`    | int                 | 0       | Skip first n results                           |
-| `--count`     | bool                | false   | Show count only                                |
+| Flag            | Short | Type                | Default | Description                                    |
+| --------------- | ----- | ------------------- | ------- | ---------------------------------------------- |
+| `--since`       |       | string              |         | Start time                                     |
+| `--until`       |       | string              |         | End time                                       |
+| `--today`       |       | bool                | false   | Filter to today                                |
+| `--yesterday`   |       | bool                | false   | Filter to yesterday                            |
+| `--agent`       |       | string (repeatable) |         | Filter by agent                                |
+| `--session`     |       | string              |         | Filter by session ID (prefix match)            |
+| `--action`      |       | string (repeatable) |         | Filter by action type                          |
+| `--file`        |       | string              |         | Filter by file path (glob)                     |
+| `--command`     |       | string              |         | Filter by command (glob)                       |
+| `--status`      |       | string              |         | Filter by result status                        |
+| `--sensitive`   |       | bool                | false   | Filter to events with sensitive file access    |
+| `--interactive` | `-i`  | bool                | false   | Launch interactive TUI browser                 |
+| `--format`      |       | string              | table   | Output format: `table`, `json`, `jsonl`, `csv` |
+| `--limit`       |       | int                 | 100     | Maximum results                                |
+| `--offset`      |       | int                 | 0       | Skip first n results                           |
+| `--count`       |       | bool                | false   | Show count only                                |
+| `--sort`        |       | string              | asc     | Sort order: `asc`, `desc`                      |
 
 ### sessions
 
@@ -177,23 +181,80 @@ The `<event-id>` argument supports full UUID or prefix match.
 | ---------- | ------ | ------- | -------------------------------- |
 | `--format` | string | unified | Output format: `unified`, `json` |
 
-### export
+### cat
 
-Export audit data for external analysis.
+Show the full detail of one or more events: payload, diff, raw event, and conversation context, subject to the configured logging level.
 
 ```bash
-gryph export --format json -o events.json
-gryph export --since "1w" --format csv
-gryph export --agent claude-code --format jsonl
+gryph cat <event-id>
+gryph cat a1b2c3d4 e5f6a7b8 --format json
 ```
 
-| Flag       | Short | Type   | Default | Description                           |
-| ---------- | ----- | ------ | ------- | ------------------------------------- |
-| `--since`  |       | string |         | Export events since                   |
-| `--until`  |       | string |         | Export events until                   |
-| `--agent`  |       | string |         | Filter by agent                       |
-| `--format` |       | string | jsonl   | Output format: `json`, `jsonl`, `csv` |
-| `--output` | `-o`  | string | stdout  | Write to file                         |
+Each `<event-id>` argument supports full UUID or prefix match.
+
+| Flag       | Type   | Default | Description                                    |
+| ---------- | ------ | ------- | ---------------------------------------------- |
+| `--format` | string | table   | Output format: `table`, `json`, `jsonl`, `csv` |
+
+### export
+
+Export raw events as JSON Lines for external analysis. Each line is one complete event object with a `$schema` field. The summary line goes to stderr, so stdout stays clean for pipes. Sensitive events are excluded by default.
+
+```bash
+gryph export
+gryph export --since "1w" -o audit.jsonl
+gryph export --agent claude-code --sensitive
+```
+
+| Flag          | Short | Type   | Default | Description                         |
+| ------------- | ----- | ------ | ------- | ----------------------------------- |
+| `--since`     |       | string | 1h      | Export events since                 |
+| `--until`     |       | string |         | Export events until                 |
+| `--agent`     |       | string |         | Filter by agent                     |
+| `--session`   |       | string |         | Filter by session ID (prefix match) |
+| `--sensitive` |       | bool   | false   | Include sensitive events            |
+| `--output`    | `-o`  | string | stdout  | Write to file                       |
+
+### cost
+
+Show per-session token usage and estimated cost across models and agents. See [docs/cost.md](cost.md) for how cost data is collected.
+
+```bash
+gryph cost
+gryph cost --since 7d --by model
+gryph cost --agent claude-code --sync
+```
+
+| Flag          | Type   | Default | Description                                 |
+| ------------- | ------ | ------- | ------------------------------------------- |
+| `--since`     | string |         | Show costs since (e.g., `1h`, `2d`)         |
+| `--until`     | string |         | Show costs until                            |
+| `--today`     | bool   | false   | Shorthand for since midnight                |
+| `--yesterday` | bool   | false   | Filter to yesterday                         |
+| `--agent`     | string |         | Filter by agent                             |
+| `--model`     | string |         | Filter by model name                        |
+| `--session`   | string |         | Filter by session ID (prefix match)         |
+| `--by`        | string | session | Group by: `session`, `model`, `agent`, `day` |
+| `--sync`      | bool   | false   | Collect or refresh cost data before display |
+| `--force`     | bool   | false   | With `--sync`: recompute even if computed   |
+| `--limit`     | int    | 100     | Maximum sessions                            |
+| `--format`    | string | table   | Output format: `table`, `json`              |
+
+### stats
+
+Open an interactive full-screen statistics dashboard.
+
+```bash
+gryph stats
+gryph stats --since 7d
+gryph stats --since 30d --agent claude-code
+```
+
+| Flag      | Type   | Default | Description                                            |
+| --------- | ------ | ------- | ------------------------------------------------------ |
+| `--since` | string | today   | Time range: `today`, `7d`, `30d`, `all`, or a duration |
+| `--until` | string |         | End of time window (same syntax as `--since`)          |
+| `--agent` | string |         | Filter by agent name                                   |
 
 ### config
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/cel-go v0.27.0
 	github.com/google/uuid v1.6.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/rogpeppe/go-internal v1.16.0
 	github.com/safedep/dry v0.0.0-20260129144613-fb1274e99a19
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -69,6 +70,7 @@ require (
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,6 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
@@ -101,8 +99,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWbZV6S5g=
+github.com/rogpeppe/go-internal v1.16.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safedep/dry v0.0.0-20260129144613-fb1274e99a19 h1:Mx9NLD9D6ymfMsDNRCVB3EtFtIWkRcX6mbVJinttrx0=
 github.com/safedep/dry v0.0.0-20260129144613-fb1274e99a19/go.mod h1:g/mexfBkT4Nbvj+QQSHY3Q7EOkhhDDlERfwufyZwGZM=

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -90,6 +90,10 @@ The harness adds three commands to the testscript builtins:
   sandbox-absolute path.
 - `replace <file> <old> <new>` substitutes a literal string in a file. Tamper
   cases use it.
+- `capture <var> <pattern> [file]` extracts one regexp capture group into a
+  script environment variable, from the last exec's stdout or from a file.
+  Use it for values not known when the script is authored, such as a deferral
+  id or a signature.
 
 ## Run it
 

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -23,6 +23,7 @@ test/acceptance/
   catalog.go            # catalog schema, loader, id derivation, selector
   integrity_test.go     # TestCatalogIntegrity: guards catalog and script drift (normal CI)
   acceptance_test.go    # TestAcceptance: real-binary harness (//go:build acceptance)
+  report/               # joins JUnit results with the catalog into a Markdown report
   scripts/
     <category>/<capability>/<name>.txtar
 ```
@@ -105,4 +106,14 @@ GRYPH_BIN=$PWD/bin/gryph go test -tags acceptance ./test/acceptance/
 # Filter by category or labels:
 ACCEPTANCE_CATEGORY=policy go test -tags acceptance ./test/acceptance/
 ACCEPTANCE_LABELS=block,receipts go test -tags acceptance ./test/acceptance/
+
+# Render the per-guarantee report from a JUnit file (what CI does):
+gotestsum --junitfile acceptance.xml -- -tags acceptance ./test/acceptance
+go run ./test/acceptance/report -junit acceptance.xml \
+  -catalog test/acceptance/catalog.yaml -scripts test/acceptance/scripts
 ```
+
+The report groups guarantees by category, then tier: pass, fail, skip,
+unknown, gap. It shows the guarantee text and, for a failure, the captured
+line. It exits zero for normal results. A missing or broken JUnit file is an
+error, not zero coverage.

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -1,0 +1,108 @@
+# Gryph Acceptance Suite
+
+The suite runs the real `gryph` binary through user-facing commands and checks
+that Gryph keeps its promises. Every script isolates itself with `HOME`,
+`XDG_CONFIG_HOME`, and `XDG_DATA_HOME` under its own work directory. Nothing
+touches the host system, and no script needs the network. The `status` and
+`doctor` commands may call the GitHub API for the update check. That check
+fails soft, so no network never fails a script.
+
+The suite is hermetic, so it gates. CI runs it on every pull request and every
+push to main.
+
+The other suites stay separate. `test/cli` runs `cli.NewRootCmd()` in process
+and owns pipeline correctness. `test/conformance/aarm` owns AARM spec
+conformance. This suite owns the real-binary contracts: exit codes, on-disk
+file shapes, stdout and stderr formats, and PATH-resolved hook commands.
+
+## Files
+
+```
+test/acceptance/
+  catalog.yaml          # guarantee inventory: id, category, tier, guarantee, labels
+  catalog.go            # catalog schema, loader, id derivation, selector
+  integrity_test.go     # TestCatalogIntegrity: guards catalog and script drift (normal CI)
+  acceptance_test.go    # TestAcceptance: real-binary harness (//go:build acceptance)
+  scripts/
+    <category>/<capability>/<name>.txtar
+```
+
+## Feature id
+
+A script's feature id is its path under `scripts/`, without `.txtar`, with `/`
+kept:
+
+```
+scripts/policy/block/dangerous-command.txtar -> policy/block/dangerous-command
+```
+
+The subtest name, `TestCatalogIntegrity`, and the catalog use this rule to
+agree on identity. Put every script at least two levels deep:
+`<category>/.../<name>.txtar`.
+
+## Add a case
+
+1. Add a script at `scripts/<category>/.../<name>.txtar`.
+2. Add a row to `catalog.yaml`:
+
+   ```yaml
+   - id: <category>/.../<name>
+     title: "short title"
+     category: <category>
+     tier: P0                 # P0 | P1 | P2
+     guarantee: "what must hold"
+     labels: [policy, block]  # optional
+   ```
+
+That is the whole change: one script, one catalog row. No scaffolding, no
+per-case Go code.
+
+`TestCatalogIntegrity` runs under normal `go test ./...`. It fails when a
+script has no catalog row, so a typo cannot become an untracked guarantee. A
+catalog row with no script is a gap. It never fails the build.
+
+## Write a script
+
+Scripts are [`testscript`](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript)
+txtar files. The harness puts `gryph` on `$PATH`, so `exec gryph ...` runs the
+real built binary.
+
+Start every script with the sandbox environment:
+
+```
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+```
+
+Embedded txtar files extract under `$WORK`, so a file section named
+`home/.config/gryph/config.yaml` becomes the sandbox config with no copy step.
+Feed hook payloads with `stdin <file>` before the `exec gryph _hook ...` line.
+
+The harness adds three commands to the testscript builtins:
+
+- `execexit <code> <command> [args...]` runs a command and asserts its exact
+  exit code. Use it for every non-zero exit-code contract. The plain `! exec`
+  form only distinguishes zero from non-zero.
+- `expandenv <file>...` rewrites `${VAR}` references in a file with values
+  from the script environment. Use it when a JSON fixture needs a
+  sandbox-absolute path.
+- `replace <file> <old> <new>` substitutes a literal string in a file. Tamper
+  cases use it.
+
+## Run it
+
+```bash
+# Catalog integrity only (fast, offline, part of normal CI):
+go test ./test/acceptance/ -run TestCatalogIntegrity
+
+# Full suite (builds the binary from ../../cmd/gryph):
+go test -tags acceptance ./test/acceptance/
+
+# Reuse a prebuilt binary:
+GRYPH_BIN=$PWD/bin/gryph go test -tags acceptance ./test/acceptance/
+
+# Filter by category or labels:
+ACCEPTANCE_CATEGORY=policy go test -tags acceptance ./test/acceptance/
+ACCEPTANCE_LABELS=block,receipts go test -tags acceptance ./test/acceptance/
+```

--- a/test/acceptance/acceptance_test.go
+++ b/test/acceptance/acceptance_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -82,6 +83,7 @@ func TestAcceptance(t *testing.T) {
 					"execexit":  cmdExecExit,
 					"expandenv": cmdExpandEnv,
 					"replace":   cmdReplace,
+					"capture":   cmdCapture,
 				},
 			})
 		})
@@ -162,6 +164,38 @@ func cmdReplace(ts *testscript.TestScript, neg bool, args []string) {
 		ts.Fatalf("replace: %s does not contain %q", args[0], args[1])
 	}
 	ts.Check(os.WriteFile(path, []byte(strings.ReplaceAll(string(data), args[1], args[2])), 0o600))
+}
+
+// cmdCapture extracts one regexp capture group into a script environment
+// variable. Dynamic values (a deferral id, a signature) are not known when a
+// script is authored, so scripts capture them from output:
+//
+//	capture DEFER_ID '"id": "([0-9a-f-]+)"'
+//	capture SIG '"signature":"([A-Za-z0-9+/=]+)"' signed.jsonl
+//
+// The source is the stdout of the last exec, or the named file.
+func cmdCapture(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("capture does not support negation")
+	}
+	if len(args) < 2 || len(args) > 3 {
+		ts.Fatalf("usage: capture <var> <pattern-with-one-group> [file]")
+	}
+	src := ""
+	if len(args) == 3 {
+		data, err := os.ReadFile(ts.MkAbs(args[2]))
+		ts.Check(err)
+		src = string(data)
+	} else {
+		src = ts.ReadFile("stdout")
+	}
+	re, err := regexp.Compile(args[1])
+	ts.Check(err)
+	m := re.FindStringSubmatch(src)
+	if len(m) < 2 {
+		ts.Fatalf("capture: pattern %q did not match or has no capture group", args[1])
+	}
+	ts.Setenv(args[0], m[1])
 }
 
 type scriptFile struct {

--- a/test/acceptance/acceptance_test.go
+++ b/test/acceptance/acceptance_test.go
@@ -1,0 +1,215 @@
+//go:build acceptance
+
+package acceptance
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAcceptance runs the real gryph binary through testscript scripts. Each
+// script isolates itself with HOME, XDG_CONFIG_HOME, and XDG_DATA_HOME under
+// its own $WORK directory. Nothing touches the host system.
+func TestAcceptance(t *testing.T) {
+	bin := os.Getenv("GRYPH_BIN")
+	if bin == "" {
+		bin = filepath.Join(t.TempDir(), "gryph")
+		build := exec.Command("go", "build", "-o", bin, "../../cmd/gryph")
+		build.Stderr = os.Stderr
+		require.NoError(t, build.Run(), "build gryph for acceptance run")
+	}
+	// testscript resolves exec targets via PATH from each script's cwd, so a
+	// relative GRYPH_BIN would never resolve. Anchor it to an absolute path.
+	bin, err := filepath.Abs(bin)
+	require.NoError(t, err)
+	binDir := filepath.Dir(bin)
+
+	cat, err := LoadCatalog("catalog.yaml")
+	require.NoError(t, err)
+	sel := selectorFromEnv()
+
+	const root = "scripts"
+	files, err := discoverScriptFiles(root)
+	require.NoError(t, err)
+	require.NotEmptyf(t, files, "no acceptance scripts found under %s", root)
+
+	// Group the selected scripts by directory. testscript names each subtest
+	// by the script's base name. Wrapping a directory in t.Run(relDir)
+	// rebuilds the full path-derived feature id in the test name.
+	byDir := map[string][]string{}
+	dirs := []string{}
+	for _, f := range files {
+		if !cat.Selects(f.id, sel) {
+			continue
+		}
+		if _, seen := byDir[f.relDir]; !seen {
+			dirs = append(dirs, f.relDir)
+		}
+		byDir[f.relDir] = append(byDir[f.relDir], f.path)
+	}
+	if len(byDir) == 0 {
+		t.Skipf("no acceptance scripts match selector %+v", sel)
+	}
+	sort.Strings(dirs)
+
+	for _, relDir := range dirs {
+		relDir, scripts := relDir, byDir[relDir]
+		t.Run(relDir, func(t *testing.T) {
+			testscript.Run(t, testscript.Params{
+				Files: scripts,
+				Setup: func(env *testscript.Env) error {
+					env.Setenv("PATH", binDir+string(os.PathListSeparator)+env.Getenv("PATH"))
+					// The status and doctor commands run an async update check
+					// against the GitHub API. Forward proxy and TLS settings so
+					// the check works in proxied environments. The check fails
+					// soft, so no network never fails a script.
+					forwardHostEnv(env,
+						"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+						"http_proxy", "https_proxy", "no_proxy",
+						"SSL_CERT_FILE", "SSL_CERT_DIR")
+					return nil
+				},
+				Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
+					"execexit":  cmdExecExit,
+					"expandenv": cmdExpandEnv,
+					"replace":   cmdReplace,
+				},
+			})
+		})
+	}
+}
+
+// cmdExecExit runs a command and asserts its exact exit code:
+//
+//	execexit 2 gryph _hook claude-code PreToolUse
+//
+// The plain `exec` builtin only distinguishes zero from non-zero. Exit codes
+// are a user-facing contract (see cli/errors.go), so scripts assert them
+// exactly.
+func cmdExecExit(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("execexit does not support negation. Assert the expected code instead")
+	}
+	if len(args) < 2 {
+		ts.Fatalf("usage: execexit <code> <command> [args...]")
+	}
+	want, err := strconv.Atoi(args[0])
+	if err != nil {
+		ts.Fatalf("execexit: bad exit code %q: %v", args[0], err)
+	}
+
+	got := 0
+	if err := ts.Exec(args[1], args[2:]...); err != nil {
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) {
+			ts.Fatalf("execexit: %s did not run: %v", args[1], err)
+		}
+		got = ee.ExitCode()
+	}
+	if got != want {
+		ts.Fatalf("execexit: %s exited %d, want %d", strings.Join(args[1:], " "), got, want)
+	}
+}
+
+// cmdExpandEnv rewrites ${VAR} references in the given files with values from
+// the script environment. txtar file sections are static, so this is how a
+// fixture embeds a sandbox-absolute path:
+//
+//	expandenv payload.json
+func cmdExpandEnv(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("expandenv does not support negation")
+	}
+	if len(args) == 0 {
+		ts.Fatalf("usage: expandenv <file>...")
+	}
+	for _, name := range args {
+		path := ts.MkAbs(name)
+		data, err := os.ReadFile(path)
+		ts.Check(err)
+		expanded := os.Expand(string(data), func(key string) string {
+			return ts.Getenv(key)
+		})
+		ts.Check(os.WriteFile(path, []byte(expanded), 0o600))
+	}
+}
+
+// cmdReplace substitutes every occurrence of a literal string in a file:
+//
+//	replace receipts.jsonl old new
+//
+// Tamper cases use it to alter one exported field before verification.
+func cmdReplace(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("replace does not support negation")
+	}
+	if len(args) != 3 {
+		ts.Fatalf("usage: replace <file> <old> <new>")
+	}
+	path := ts.MkAbs(args[0])
+	data, err := os.ReadFile(path)
+	ts.Check(err)
+	if !strings.Contains(string(data), args[1]) {
+		ts.Fatalf("replace: %s does not contain %q", args[0], args[1])
+	}
+	ts.Check(os.WriteFile(path, []byte(strings.ReplaceAll(string(data), args[1], args[2])), 0o600))
+}
+
+type scriptFile struct {
+	path   string // path to the .txtar, relative to the working directory
+	relDir string // directory relative to the scripts root, "/"-separated
+	id     string // path-derived feature id
+}
+
+func discoverScriptFiles(root string) ([]scriptFile, error) {
+	var out []scriptFile
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".txtar" {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out = append(out, scriptFile{
+			path:   path,
+			relDir: filepath.ToSlash(filepath.Dir(rel)),
+			id:     DeriveFeatureID(rel),
+		})
+		return nil
+	})
+	return out, err
+}
+
+// selectorFromEnv reads the optional category and label filters. CI passes
+// them as environment variables, never as shell arguments, so a dispatch
+// input cannot inject into a command.
+func selectorFromEnv() Selector {
+	sel := Selector{Category: strings.TrimSpace(os.Getenv("ACCEPTANCE_CATEGORY"))}
+	for _, l := range strings.Split(os.Getenv("ACCEPTANCE_LABELS"), ",") {
+		if l = strings.TrimSpace(l); l != "" {
+			sel.Labels = append(sel.Labels, l)
+		}
+	}
+	return sel
+}
+
+func forwardHostEnv(env *testscript.Env, keys ...string) {
+	for _, key := range keys {
+		if v, ok := os.LookupEnv(key); ok && v != "" {
+			env.Setenv(key, v)
+		}
+	}
+}

--- a/test/acceptance/catalog.go
+++ b/test/acceptance/catalog.go
@@ -1,0 +1,154 @@
+// Package acceptance holds the gryph acceptance suite. The catalog is the
+// guarantee inventory. Every script under scripts/ maps to one catalog row by
+// its path-derived feature id.
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Tier string
+
+const (
+	TierP0 Tier = "P0"
+	TierP1 Tier = "P1"
+	TierP2 Tier = "P2"
+)
+
+type Guarantee struct {
+	ID        string   `yaml:"id"`
+	Title     string   `yaml:"title"`
+	Category  string   `yaml:"category"`
+	Tier      Tier     `yaml:"tier"`
+	Guarantee string   `yaml:"guarantee"`
+	Labels    []string `yaml:"labels"`
+}
+
+type Catalog struct {
+	guarantees []Guarantee
+	byID       map[string]Guarantee
+}
+
+// Selector filters guarantees by category and labels. An empty Category
+// matches every category. Empty Labels match every guarantee. When Labels is
+// set, a guarantee matches when it carries at least one requested label.
+type Selector struct {
+	Category string
+	Labels   []string
+}
+
+func (s Selector) Empty() bool { return s.Category == "" && len(s.Labels) == 0 }
+
+// Selects reports whether the guarantee with the given id passes the
+// selector. An id with no catalog entry passes only when the selector is
+// empty. A filtered run never includes an un-cataloged script.
+func (c *Catalog) Selects(id string, sel Selector) bool {
+	g, ok := c.byID[id]
+	if !ok {
+		return sel.Empty()
+	}
+	if sel.Category != "" && g.Category != sel.Category {
+		return false
+	}
+	if len(sel.Labels) > 0 && !hasAnyLabel(g.Labels, sel.Labels) {
+		return false
+	}
+	return true
+}
+
+func hasAnyLabel(have, want []string) bool {
+	for _, w := range want {
+		for _, h := range have {
+			if h == w {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func LoadCatalog(path string) (*Catalog, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read catalog: %w", err)
+	}
+
+	var gs []Guarantee
+	if err := yaml.Unmarshal(data, &gs); err != nil {
+		return nil, fmt.Errorf("parse catalog: %w", err)
+	}
+
+	c := &Catalog{guarantees: gs, byID: make(map[string]Guarantee, len(gs))}
+	for _, g := range gs {
+		if g.ID == "" {
+			return nil, fmt.Errorf("catalog entry with empty id: %+v", g)
+		}
+		// The category must equal the id's first path segment. Selects filters
+		// on it and the report groups by it. A typo would silently mis-filter
+		// instead of failing.
+		if head, _, _ := strings.Cut(g.ID, "/"); g.Category != head {
+			return nil, fmt.Errorf("catalog %s: category %q must match id head %q", g.ID, g.Category, head)
+		}
+		if _, dup := c.byID[g.ID]; dup {
+			return nil, fmt.Errorf("duplicate catalog id: %s", g.ID)
+		}
+		switch g.Tier {
+		case TierP0, TierP1, TierP2:
+		default:
+			return nil, fmt.Errorf("invalid tier %q for %s (want P0|P1|P2)", g.Tier, g.ID)
+		}
+		c.byID[g.ID] = g
+	}
+	return c, nil
+}
+
+func (c *Catalog) Has(id string) bool { _, ok := c.byID[id]; return ok }
+
+func (c *Catalog) Get(id string) (Guarantee, bool) { g, ok := c.byID[id]; return g, ok }
+
+func (c *Catalog) Guarantees() []Guarantee { return c.guarantees }
+
+func (c *Catalog) IDs() []string {
+	ids := make([]string, 0, len(c.byID))
+	for id := range c.byID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// DeriveFeatureID turns a script path relative to the scripts root into its
+// feature id. It drops the .txtar extension and keeps "/" separators.
+func DeriveFeatureID(relPath string) string {
+	return strings.TrimSuffix(filepath.ToSlash(relPath), ".txtar")
+}
+
+// DiscoverScripts returns the feature id of every .txtar under root.
+func DiscoverScripts(root string) ([]string, error) {
+	var ids []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".txtar") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		ids = append(ids, DeriveFeatureID(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(ids)
+	return ids, nil
+}

--- a/test/acceptance/catalog.yaml
+++ b/test/acceptance/catalog.yaml
@@ -75,3 +75,89 @@
   tier: P1
   guarantee: "After install, gryph status shows the agent as installed and gryph doctor exits zero with passing checks."
   labels: [status, doctor]
+
+- id: policy/fail-mode/closed-on-broken-policy
+  title: "a broken policy fails closed, never silently off"
+  category: policy
+  tier: P0
+  guarantee: "With fail_mode closed, a policy that does not load blocks the action and records a policy_load_error self-audit. With fail_mode open the action passes."
+  labels: [policy, fail-mode, self-audit]
+
+- id: policy/authoring/install-multi-file
+  title: "policy validate, install, and list work end to end"
+  category: policy
+  tier: P0
+  guarantee: "gryph policy validate --file checks a draft, policy install copies it into policies/, policy list shows the merged sources, and the installed rule enforces."
+  labels: [policy, authoring]
+
+- id: install/all-agents/files-written
+  title: "one install covers every detected agent's documented file"
+  category: install
+  tier: P0
+  guarantee: "gryph install writes each detected agent's hook file as documented, and gryph uninstall removes every gryph entry and generated file."
+  labels: [install, all-agents]
+
+- id: hook/protocols/block-matrix
+  title: "every agent protocol refuses a blocked action"
+  category: hook
+  tier: P0
+  guarantee: "A block decision reaches gemini, opencode, windsurf, pi-agent, and codex through each protocol's exit code and response channel, and every event persists as blocked."
+  labels: [policy, block, protocols]
+
+- id: policy/defer/timeout-resolves-deny
+  title: "a deferred action resolves by decision or times out to deny"
+  category: policy
+  tier: P0
+  guarantee: "A defer decision blocks the action and queues it. A human resolves it with a decision. The sweep resolves an expired deferral to timeout, which denies."
+  labels: [policy, defer]
+
+- id: policy/guidance/advisory-delivered
+  title: "a guidance rule advises without blocking"
+  category: policy
+  tier: P1
+  guarantee: "A guidance decision exits zero, delivers the advisory on the agent's channel, and persists the event as success."
+  labels: [policy, guidance, claude-code, cursor]
+
+- id: receipts/signing/key-round-trip
+  title: "signed receipts verify and a tampered signature fails"
+  category: receipts
+  tier: P1
+  guarantee: "After keys generate, receipts are signed, verify-log validates them against the trust store, and a tampered signature fails verification with a non-zero exit."
+  labels: [policy, receipts, signing]
+
+- id: cost/tokens/from-transcript
+  title: "session end collects token usage from the transcript"
+  category: cost
+  tier: P1
+  guarantee: "A session end hook with a transcript path makes gryph cost report the session's tokens and model."
+  labels: [cost, tokens]
+
+- id: install/purge/data-removed
+  title: "purge removes the database and config, dry-run changes nothing"
+  category: install
+  tier: P1
+  guarantee: "gryph uninstall --purge deletes the database and config and keeps foreign hooks. The --dry-run form previews without changing anything."
+  labels: [install, uninstall, purge]
+
+- id: audit/self-log/actions-recorded
+  title: "gryph records its own actions and keeps them through cleanup"
+  category: audit
+  tier: P1
+  guarantee: "Install, config change, and uninstall each leave a self-log row, and retention cleanup never deletes self-audit rows."
+  labels: [self-audit, retention]
+
+# --- gaps: tracked guarantees with no script yet ---
+
+- id: events/diff/unified-by-id
+  title: "diff and cat show event detail by id or prefix"
+  category: events
+  tier: P2
+  guarantee: "gryph diff <event-id> prints a unified diff for a file_write event and gryph cat <event-id> shows the event detail, with prefix match."
+  labels: [diff, cat]
+
+- id: retention/cleanup/old-events-deleted
+  title: "retention cleanup deletes events past the cutoff"
+  category: retention
+  tier: P2
+  guarantee: "gryph retention cleanup deletes events older than the configured retention and reports the count, and --dry-run only previews."
+  labels: [retention]

--- a/test/acceptance/catalog.yaml
+++ b/test/acceptance/catalog.yaml
@@ -1,0 +1,77 @@
+# Guarantee inventory for the gryph acceptance suite. One entry per guarantee.
+# Coverage is derived: a script whose path id matches means covered. Never
+# author a coverage field.
+#
+# The category is the first path segment of the script id.
+# The tier is P0 (incident) | P1 (important) | P2 (tracked).
+# Labels are free-form tags. A run can filter by category and by labels.
+
+- id: install/claude-code/hooks-written
+  title: "gryph install writes Claude Code hooks and keeps foreign entries"
+  category: install
+  tier: P0
+  guarantee: "gryph install --agent claude-code adds gryph hook entries to ~/.claude/settings.json and keeps pre-existing hooks and settings."
+  labels: [install, claude-code]
+
+- id: install/uninstall/round-trip
+  title: "gryph uninstall removes only gryph hooks and restores backups"
+  category: install
+  tier: P0
+  guarantee: "gryph uninstall removes gryph hook entries, keeps foreign hooks, writes a backup on install, and --restore-backup brings the original file back."
+  labels: [install, uninstall, backup, claude-code]
+
+- id: hook/ingest/event-persisted
+  title: "a hook payload becomes a queryable event in one session"
+  category: hook
+  tier: P0
+  guarantee: "gryph _hook parses a real agent payload from stdin, exits zero, persists the event, and maps repeated payloads of one agent session to one gryph session."
+  labels: [hook, ingest, claude-code]
+
+- id: policy/block/dangerous-command
+  title: "a policy block rule stops the action with the agent's protocol"
+  category: policy
+  tier: P0
+  guarantee: "A matching block rule makes the Claude Code hook exit 2 with the reason, makes the Cursor hook exit 0 with a deny JSON on stdout, and persists the event as blocked."
+  labels: [policy, block, claude-code, cursor]
+
+- id: policy/self-protection/config-write-blocked
+  title: "builtin self-protection blocks writes to gryph and hook config"
+  category: policy
+  tier: P0
+  guarantee: "With policy enabled, an agent write to the gryph config directory or an agent hook config file is blocked by the builtin rules."
+  labels: [policy, self-protection]
+
+- id: privacy/sensitive/content-never-stored
+  title: "sensitive file content never reaches storage or export"
+  category: privacy
+  tier: P0
+  guarantee: "A write to a sensitive path is flagged, its content is not stored at any logging level, and export excludes the event unless --sensitive is set."
+  labels: [privacy, sensitive, redaction, export]
+
+- id: receipts/verify-log/tamper-fails
+  title: "receipt log verification detects tampering"
+  category: receipts
+  tier: P1
+  guarantee: "gryph policy receipts verify-log exits zero on an untampered export and exits non-zero after one field changes."
+  labels: [policy, receipts, aarm]
+
+- id: export/schema/jsonl-stable
+  title: "export emits schema-tagged JSONL with a clean stdout"
+  category: export
+  tier: P1
+  guarantee: "gryph export writes one JSON object per line with a $schema field and prints the summary to stderr only."
+  labels: [export, jsonl, automation]
+
+- id: errors/exit-codes/contract
+  title: "documented exit codes hold on the real binary"
+  category: errors
+  tier: P1
+  guarantee: "An unknown agent exits 4 and an invalid configuration exits 2, with the error on stderr."
+  labels: [errors, exit-codes]
+
+- id: health/status-doctor/healthy
+  title: "status and doctor report a healthy installation"
+  category: health
+  tier: P1
+  guarantee: "After install, gryph status shows the agent as installed and gryph doctor exits zero with passing checks."
+  labels: [status, doctor]

--- a/test/acceptance/integrity_test.go
+++ b/test/acceptance/integrity_test.go
@@ -1,0 +1,26 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCatalogIntegrity runs under normal `go test ./...`. It fails when a
+// script has no catalog row, so a typo cannot become an untracked guarantee.
+// A catalog row with no script is a gap. The suite reports it and never fails
+// the build for it.
+func TestCatalogIntegrity(t *testing.T) {
+	cat, err := LoadCatalog("catalog.yaml")
+	require.NoError(t, err)
+
+	scriptIDs, err := DiscoverScripts("scripts")
+	require.NoError(t, err)
+	require.NotEmpty(t, scriptIDs)
+
+	for _, id := range scriptIDs {
+		assert.Truef(t, cat.Has(id),
+			"script %q.txtar has no catalog.yaml entry. Add one so it cannot become a phantom guarantee", id)
+	}
+}

--- a/test/acceptance/integrity_test.go
+++ b/test/acceptance/integrity_test.go
@@ -19,8 +19,19 @@ func TestCatalogIntegrity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, scriptIDs)
 
+	covered := make(map[string]bool, len(scriptIDs))
 	for _, id := range scriptIDs {
+		covered[id] = true
 		assert.Truef(t, cat.Has(id),
 			"script %q.txtar has no catalog.yaml entry. Add one so it cannot become a phantom guarantee", id)
+	}
+
+	// A catalog row with no script is a gap. Report it so a renamed or
+	// deleted script cannot silently keep its coverage claim, but never fail
+	// the build for it.
+	for _, id := range cat.IDs() {
+		if !covered[id] {
+			t.Logf("gap: catalog entry %q has no script under scripts/", id)
+		}
 	}
 }

--- a/test/acceptance/report/main.go
+++ b/test/acceptance/report/main.go
@@ -1,0 +1,355 @@
+// Command report joins gotestsum JUnit results with the acceptance catalog
+// into a Markdown report grouped by category and tier. CI writes it to the
+// job summary. Status markers are ASCII on purpose.
+package main
+
+import (
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+	"strings"
+
+	acc "github.com/safedep/gryph/test/acceptance"
+)
+
+type Status string
+
+const (
+	StatusGap     Status = "gap"
+	StatusPass    Status = "pass"
+	StatusFail    Status = "fail"
+	StatusSkip    Status = "skip"
+	StatusUnknown Status = "unknown"
+)
+
+const subtestPrefix = "TestAcceptance/"
+
+type junitReport struct {
+	XMLName xml.Name     `xml:"testsuites"`
+	Suites  []junitSuite `xml:"testsuite"`
+}
+
+type junitSuite struct {
+	Cases []junitCase `xml:"testcase"`
+}
+
+type junitCase struct {
+	Name    string   `xml:"name,attr"`
+	Failure *xmlNode `xml:"failure"`
+	Skipped *xmlNode `xml:"skipped"`
+}
+
+type xmlNode struct {
+	Message string `xml:"message,attr"`
+	Body    string `xml:",chardata"`
+}
+
+type result struct {
+	status  Status
+	message string
+}
+
+func parseJUnit(data []byte) (map[string]result, error) {
+	var r junitReport
+	if err := xml.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse junit: %w", err)
+	}
+	out := map[string]result{}
+	for _, s := range r.Suites {
+		for _, c := range s.Cases {
+			if !strings.HasPrefix(c.Name, subtestPrefix) {
+				continue
+			}
+			id := strings.TrimPrefix(c.Name, subtestPrefix)
+			res := result{status: StatusPass}
+			switch {
+			case c.Failure != nil:
+				res.status = StatusFail
+				res.message = snippet(c.Failure)
+			case c.Skipped != nil:
+				res.status = StatusSkip
+				res.message = snippet(c.Skipped)
+			}
+			out[id] = res
+		}
+	}
+	return out, nil
+}
+
+// statusesFromJUnit maps each acceptance subtest id to its status. Parent
+// aggregate rows (e.g. "policy/block") are included. They are not catalog
+// ids, so summarize ignores them.
+func statusesFromJUnit(data []byte) (map[string]Status, error) {
+	res, err := parseJUnit(data)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]Status, len(res))
+	for id, r := range res {
+		out[id] = r.status
+	}
+	return out, nil
+}
+
+// snippet extracts the most useful single line from a gotestsum failure or
+// skip body. gotestsum captures the whole `go test` log, whose first lines
+// are the "=== RUN" headers and the testscript env dump, not the reason.
+// Prefer the testscript assertion line ("... .txtar:NN: <reason>"). Fall
+// back to the first line that is not a go-test header or env dump.
+func snippet(n *xmlNode) string {
+	lines := strings.Split(n.Body, "\n")
+	for _, ln := range lines {
+		s := strings.TrimSpace(ln)
+		if strings.Contains(s, ".txtar:") {
+			return truncate(s)
+		}
+	}
+	for _, ln := range lines {
+		s := strings.TrimSpace(ln)
+		if s == "" || isTestLogNoise(s) {
+			continue
+		}
+		return truncate(s)
+	}
+	if m := strings.TrimSpace(n.Message); m != "" && !isTestLogNoise(m) {
+		return truncate(m)
+	}
+	return ""
+}
+
+func isTestLogNoise(s string) bool {
+	for _, p := range []string{"=== RUN", "=== PAUSE", "=== CONT", "=== NAME", "--- FAIL", "--- PASS", "--- SKIP"} {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	// The testscript env dump: "testscript.go:NN: WORK=..." then indented KEY=VALUE lines.
+	return strings.HasPrefix(s, "testscript.go:") || strings.Contains(s, "=$WORK")
+}
+
+func truncate(line string) string {
+	const max = 200
+	if len(line) > max {
+		return line[:max] + "..."
+	}
+	return line
+}
+
+type Row struct {
+	G      acc.Guarantee
+	Status Status
+}
+
+type Summary struct {
+	Rows   []Row
+	Counts map[Status]int
+}
+
+// summarize joins the catalog with the JUnit statuses. An id with a result
+// takes that status. An id with no result but a script on disk is unknown
+// (the run did not report it), distinct from a gap (no script authored yet).
+func summarize(cat *acc.Catalog, st map[string]Status, scripts map[string]bool) Summary {
+	sum := Summary{Counts: map[Status]int{}}
+	for _, id := range cat.IDs() {
+		g, _ := cat.Get(id)
+		s := StatusGap
+		switch {
+		case st[id] != "":
+			s = st[id]
+		case scripts[id]:
+			s = StatusUnknown
+		}
+		sum.Rows = append(sum.Rows, Row{G: g, Status: s})
+		sum.Counts[s]++
+	}
+	return sum
+}
+
+func marker(s Status) string {
+	switch s {
+	case StatusPass:
+		return "[ok]"
+	case StatusFail:
+		return "[FAIL]"
+	case StatusSkip:
+		return "[skip]"
+	case StatusUnknown:
+		return "[?]"
+	default:
+		return "[gap]"
+	}
+}
+
+var tierOrder = []acc.Tier{acc.TierP0, acc.TierP1, acc.TierP2}
+
+// errWriter accumulates the first write error so the report builders stay
+// readable while still checking every fmt.Fprintf.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) printf(format string, a ...any) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, a...)
+}
+
+func render(w io.Writer, sum Summary, messages map[string]result) error {
+	ew := &errWriter{w: w}
+	ew.printf("# Gryph Acceptance Report\n\n")
+	ew.printf("%d pass, %d fail, %d skip, %d unknown, %d gap\n\n",
+		sum.Counts[StatusPass], sum.Counts[StatusFail], sum.Counts[StatusSkip],
+		sum.Counts[StatusUnknown], sum.Counts[StatusGap])
+
+	renderTierRollup(ew, sum)
+
+	byCategory := map[string][]Row{}
+	categories := []string{}
+	for _, r := range sum.Rows {
+		if _, seen := byCategory[r.G.Category]; !seen {
+			categories = append(categories, r.G.Category)
+		}
+		byCategory[r.G.Category] = append(byCategory[r.G.Category], r)
+	}
+	sort.Strings(categories)
+
+	for _, category := range categories {
+		ew.printf("## %s\n\n| | Tier | Guarantee | Detail |\n|---|---|---|---|\n", category)
+		rows := byCategory[category]
+		sortRowsByTier(rows)
+		for _, r := range rows {
+			detail := r.G.Guarantee
+			if r.Status == StatusFail || r.Status == StatusSkip {
+				if m, ok := messages[r.G.ID]; ok && m.message != "" {
+					detail = fmt.Sprintf("%s - %s", r.G.Guarantee, m.message)
+				}
+			}
+			ew.printf("| %s | %s | `%s` | %s |\n", marker(r.Status), r.G.Tier, r.G.ID, mdCell(detail))
+		}
+		ew.printf("\n")
+	}
+	return ew.err
+}
+
+func renderTierRollup(ew *errWriter, sum Summary) {
+	perTier := map[acc.Tier]map[Status]int{}
+	for _, r := range sum.Rows {
+		if perTier[r.G.Tier] == nil {
+			perTier[r.G.Tier] = map[Status]int{}
+		}
+		perTier[r.G.Tier][r.Status]++
+	}
+
+	ew.printf("| Tier | pass | fail | skip | unknown | gap | coverage |\n|---|---|---|---|---|---|---|\n")
+	for _, tier := range tierOrder {
+		c := perTier[tier]
+		total := c[StatusPass] + c[StatusFail] + c[StatusSkip] + c[StatusUnknown] + c[StatusGap]
+		ew.printf("| %s | %d | %d | %d | %d | %d | %d/%d |\n",
+			tier, c[StatusPass], c[StatusFail], c[StatusSkip], c[StatusUnknown], c[StatusGap],
+			c[StatusPass], total)
+	}
+	ew.printf("\n")
+}
+
+func sortRowsByTier(rows []Row) {
+	rank := map[acc.Tier]int{acc.TierP0: 0, acc.TierP1: 1, acc.TierP2: 2}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].G.Tier != rows[j].G.Tier {
+			return rank[rows[i].G.Tier] < rank[rows[j].G.Tier]
+		}
+		return rows[i].G.ID < rows[j].G.ID
+	})
+}
+
+func mdCell(s string) string {
+	return strings.ReplaceAll(s, "|", "\\|")
+}
+
+// loadScriptIDs returns the set of feature ids that have a script on disk. A
+// missing scripts directory is not fatal. Script awareness only refines gap
+// versus unknown, so the report still renders without it.
+func loadScriptIDs(root string) map[string]bool {
+	ids, err := acc.DiscoverScripts(root)
+	if err != nil {
+		log.Printf("discover scripts under %s: %v (gap/unknown split disabled)", root, err)
+		return nil
+	}
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set
+}
+
+func run() error {
+	junitPath := flag.String("junit", "", "path to gotestsum JUnit XML")
+	catalogPath := flag.String("catalog", "test/acceptance/catalog.yaml", "path to catalog.yaml")
+	scriptsPath := flag.String("scripts", "test/acceptance/scripts", "path to the acceptance scripts root")
+	flag.Parse()
+
+	cat, err := acc.LoadCatalog(*catalogPath)
+	if err != nil {
+		return fmt.Errorf("load catalog: %w", err)
+	}
+
+	scripts := loadScriptIDs(*scriptsPath)
+
+	// A missing or unparsable JUnit file when one was requested is an
+	// incomplete run, not "everything is a gap". Surface it in the report
+	// and fail, so it is never mistaken for real zero coverage.
+	results := map[string]result{}
+	if *junitPath != "" {
+		data, rerr := os.ReadFile(*junitPath)
+		if rerr != nil {
+			return junitError(cat, scripts, fmt.Errorf("read junit %s: %w", *junitPath, rerr))
+		}
+		if results, err = parseJUnit(data); err != nil {
+			return junitError(cat, scripts, fmt.Errorf("parse junit %s: %w", *junitPath, err))
+		}
+	}
+
+	statuses := make(map[string]Status, len(results))
+	for id, r := range results {
+		statuses[id] = r.status
+	}
+
+	var b strings.Builder
+	if err := render(&b, summarize(cat, statuses, scripts), results); err != nil {
+		return fmt.Errorf("render report: %w", err)
+	}
+	if _, err := fmt.Fprint(os.Stdout, b.String()); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+// junitError writes a visible report banner to stdout (so it reaches the job
+// summary) and returns the underlying error so the tool exits non-zero.
+func junitError(cat *acc.Catalog, scripts map[string]bool, cause error) error {
+	var b strings.Builder
+	ew := &errWriter{w: &b}
+	ew.printf("> WARNING: JUnit results unavailable: %s\n>\n", cause)
+	ew.printf("> The acceptance run produced no parsable results. Coverage below is unknown, not zero.\n\n")
+	if ew.err != nil {
+		return fmt.Errorf("%w (and write failed: %v)", cause, ew.err)
+	}
+	if rerr := render(&b, summarize(cat, nil, scripts), nil); rerr != nil {
+		return fmt.Errorf("%w (and render failed: %v)", cause, rerr)
+	}
+	if _, werr := fmt.Fprint(os.Stdout, b.String()); werr != nil {
+		return fmt.Errorf("%w (and write failed: %v)", cause, werr)
+	}
+	return cause
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/test/acceptance/report/report_test.go
+++ b/test/acceptance/report/report_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	acc "github.com/safedep/gryph/test/acceptance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeCatalog(t *testing.T, yaml string) *acc.Catalog {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "catalog.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+	cat, err := acc.LoadCatalog(path)
+	require.NoError(t, err)
+	return cat
+}
+
+func TestStatusesFromJUnit(t *testing.T) {
+	xmlIn := `<testsuites><testsuite>
+	  <testcase name="TestAcceptance/policy/block/dangerous-command"></testcase>
+	  <testcase name="TestAcceptance/hook/ingest/event-persisted"><failure message="boom">boom</failure></testcase>
+	  <testcase name="TestAcceptance/health/status-doctor/healthy"><skipped message="no network"></skipped></testcase>
+	  <testcase name="TestAcceptance/policy/block"></testcase>
+	</testsuite></testsuites>`
+
+	got, err := statusesFromJUnit([]byte(xmlIn))
+	require.NoError(t, err)
+	assert.Equal(t, StatusPass, got["policy/block/dangerous-command"])
+	assert.Equal(t, StatusFail, got["hook/ingest/event-persisted"])
+	assert.Equal(t, StatusSkip, got["health/status-doctor/healthy"])
+	assert.Equal(t, StatusPass, got["policy/block"]) // parent aggregate, not a catalog id
+}
+
+func TestStatusesFromJUnitIgnoresNonAcceptance(t *testing.T) {
+	xmlIn := `<testsuites><testsuite>
+	  <testcase name="TestCatalogIntegrity"></testcase>
+	  <testcase name="TestAcceptance/export/schema/jsonl-stable"></testcase>
+	</testsuite></testsuites>`
+
+	got, err := statusesFromJUnit([]byte(xmlIn))
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, StatusPass, got["export/schema/jsonl-stable"])
+}
+
+func TestSummarizeSplitsGapAndUnknown(t *testing.T) {
+	cat := writeCatalog(t, `
+- id: hook/ingest/event-persisted
+  category: hook
+  tier: P0
+  guarantee: x
+- id: policy/block/dangerous-command
+  category: policy
+  tier: P0
+  guarantee: y
+- id: export/schema/jsonl-stable
+  category: export
+  tier: P1
+  guarantee: z
+`)
+
+	// hook has a result. policy has a script but no result. export has neither.
+	scripts := map[string]bool{
+		"hook/ingest/event-persisted":    true,
+		"policy/block/dangerous-command": true,
+	}
+	sum := summarize(cat, map[string]Status{"hook/ingest/event-persisted": StatusPass}, scripts)
+	assert.Equal(t, 1, sum.Counts[StatusPass])
+	assert.Equal(t, 1, sum.Counts[StatusUnknown])
+	assert.Equal(t, 1, sum.Counts[StatusGap])
+	assert.Len(t, sum.Rows, 3)
+}
+
+func TestRenderShowsFailureSnippetAndCoverage(t *testing.T) {
+	cat := writeCatalog(t, `
+- id: policy/block/dangerous-command
+  category: policy
+  tier: P0
+  guarantee: a matching block rule stops the action
+- id: export/schema/jsonl-stable
+  category: export
+  tier: P1
+  guarantee: export emits schema-tagged JSONL
+`)
+
+	results := map[string]result{
+		"policy/block/dangerous-command": {status: StatusPass},
+		"export/schema/jsonl-stable":     {status: StatusFail, message: "unexpected command success"},
+	}
+	statuses := map[string]Status{}
+	for id, r := range results {
+		statuses[id] = r.status
+	}
+
+	var b strings.Builder
+	require.NoError(t, render(&b, summarize(cat, statuses, nil), results))
+	out := b.String()
+
+	assert.Contains(t, out, "policy/block/dangerous-command")
+	assert.Contains(t, out, "unexpected command success")
+	assert.Contains(t, out, "1/1") // P0 coverage: 1 pass of 1
+	assert.Contains(t, out, "## policy")
+	assert.Contains(t, out, "[FAIL]")
+}
+
+func TestParseJUnitRejectsMalformed(t *testing.T) {
+	_, err := statusesFromJUnit([]byte("<testsuites><not-closed"))
+	assert.Error(t, err)
+}
+
+func TestSnippetPrefersAssertionLineOverTestLogNoise(t *testing.T) {
+	body := `=== RUN   TestAcceptance/policy/block/dangerous-command
+=== PAUSE TestAcceptance/policy/block/dangerous-command
+    testscript.go:584: WORK=$WORK
+        PATH=/usr/bin
+        HOME=/no-home
+        > execexit 2 gryph _hook claude-code PreToolUse
+        FAIL: scripts/policy/block/dangerous-command.txtar:9: unexpected command success`
+	got := snippet(&xmlNode{Message: "=== RUN   TestAcceptance/policy/block/dangerous-command", Body: body})
+	assert.Equal(t, "FAIL: scripts/policy/block/dangerous-command.txtar:9: unexpected command success", got)
+}
+
+func TestSnippetSuppressesRunHeaderOnlyBody(t *testing.T) {
+	got := snippet(&xmlNode{Message: "=== RUN   TestAcceptance/health/status-doctor/healthy", Body: "=== RUN   TestAcceptance/health/status-doctor/healthy\n"})
+	assert.Equal(t, "", got)
+}

--- a/test/acceptance/scripts/audit/self-log/actions-recorded.txtar
+++ b/test/acceptance/scripts/audit/self-log/actions-recorded.txtar
@@ -1,0 +1,20 @@
+# Gryph audits itself. Install, config change, and uninstall each leave a
+# self-log row. Retention cleanup never deletes self-audit rows.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+mkdir $HOME/.claude
+exec gryph install --agent claude-code
+exec gryph config set logging.level full
+exec gryph uninstall --agent claude-code
+
+exec gryph self-log --format json --no-color
+stdout '"Action": "install"'
+stdout '"Action": "config_change"'
+stdout '"Action": "uninstall"'
+
+exec gryph retention cleanup
+exec gryph self-log --format json --no-color
+stdout '"Action": "install"'
+stdout '"Action": "uninstall"'

--- a/test/acceptance/scripts/cost/tokens/from-transcript.txtar
+++ b/test/acceptance/scripts/cost/tokens/from-transcript.txtar
@@ -1,0 +1,27 @@
+# Session end triggers cost collection from the agent transcript. The cost
+# command reports the tokens and the model.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+expandenv session_end.json
+
+stdin session_end.json
+exec gryph _hook claude-code SessionEnd
+
+exec gryph cost --format json --no-color
+stdout '"TotalTokens": 2800'
+stdout 'claude-sonnet-4-20250514'
+stdout '"InputTokens": 1500'
+stdout '"OutputTokens": 700'
+
+-- home/transcript.jsonl --
+{"type":"assistant","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":1500,"output_tokens":700,"cache_read_input_tokens":400,"cache_creation_input_tokens":200}}}
+-- session_end.json --
+{
+  "session_id": "test-session-123",
+  "transcript_path": "${WORK}/home/transcript.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "SessionEnd",
+  "reason": "user_exit"
+}

--- a/test/acceptance/scripts/errors/exit-codes/contract.txtar
+++ b/test/acceptance/scripts/errors/exit-codes/contract.txtar
@@ -1,0 +1,24 @@
+# The documented exit codes hold on the real binary:
+# 0 success, 2 config, 3 database, 4 agent not found (see cli/errors.go).
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+# 4: unknown agent.
+execexit 4 gryph install --agent doesnotexist
+stderr 'agent not found: doesnotexist'
+
+# 2: a required input is missing.
+execexit 2 gryph policy receipts verify-log
+stderr 'input is required'
+
+# 3: the database cannot open. A directory at the database path forces it.
+rm $XDG_DATA_HOME/gryph/audit.db
+mkdir $XDG_DATA_HOME/gryph/audit.db
+execexit 3 gryph logs
+stderr 'failed to open database'
+
+# 0: a healthy command.
+rm $XDG_DATA_HOME/gryph/audit.db
+exec gryph version
+stdout 'gryph'

--- a/test/acceptance/scripts/export/schema/jsonl-stable.txtar
+++ b/test/acceptance/scripts/export/schema/jsonl-stable.txtar
@@ -1,0 +1,50 @@
+# Export emits one JSON object per line with a $schema field. The summary
+# line goes to stderr, so stdout stays clean for pipes.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+stdin pre_tool_use_bash.json
+exec gryph _hook claude-code PreToolUse
+stdin post_tool_use_read.json
+exec gryph _hook claude-code PostToolUse
+
+exec gryph export --since 1h --output out.jsonl
+stderr 'Exported 2 events'
+grep '"\$schema":"https://raw.githubusercontent.com/safedep/gryph/main/schema/event.schema.json"' out.jsonl
+grep '"action_type":"command_exec"' out.jsonl
+grep '"action_type":"file_read"' out.jsonl
+
+# Without --output the events go to stdout and the summary stays on stderr.
+exec gryph export --since 1h
+stdout '"action_type":"command_exec"'
+! stdout 'Exported'
+stderr 'Exported 2 events'
+
+-- pre_tool_use_bash.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  },
+  "tool_use_id": "tool-use-001"
+}
+-- post_tool_use_read.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/user/project/README.md"
+  },
+  "tool_response": {
+    "content": "# Project README",
+    "success": true
+  },
+  "tool_use_id": "tool-use-003"
+}

--- a/test/acceptance/scripts/health/status-doctor/healthy.txtar
+++ b/test/acceptance/scripts/health/status-doctor/healthy.txtar
@@ -1,0 +1,21 @@
+# After install, status shows the agent as installed and doctor passes its
+# checks. Both commands may call the GitHub API for the update check. The
+# check fails soft, so no network never fails this script.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+mkdir $HOME/.claude
+exec gryph install --agent claude-code
+
+exec gryph status --no-color
+stdout 'claude-code\s+installed'
+stdout 'hooks: 8 active'
+stdout 'Database'
+stdout 'audit.db'
+
+exec gryph doctor --no-color
+stdout '\[ok\]\s+Database file'
+stdout '\[ok\]\s+Claude Code hooks'
+stdout 'All hooks installed and valid'
+stdout 'Schema is up to date'

--- a/test/acceptance/scripts/hook/ingest/event-persisted.txtar
+++ b/test/acceptance/scripts/hook/ingest/event-persisted.txtar
@@ -1,0 +1,55 @@
+# A real hook payload on stdin becomes a queryable event. Repeated payloads
+# for one agent session map to one gryph session with sequence numbers.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+stdin pre_tool_use_bash.json
+exec gryph _hook claude-code PreToolUse
+
+stdin post_tool_use_read.json
+exec gryph _hook claude-code PostToolUse
+
+exec gryph query --format json --no-color
+stdout '"ActionType": "command_exec"'
+stdout '"Command": "npm install"'
+stdout '"ActionType": "file_read"'
+stdout '"AgentName": "claude-code"'
+
+# Both payloads carry agent session test-session-123, so exactly one session
+# exists with both actions counted.
+exec gryph sessions --format json --no-color
+stdout -count=1 '"AgentName": "claude-code"'
+stdout '"TotalActions": 2'
+
+-- pre_tool_use_bash.json --
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  },
+  "tool_use_id": "tool-use-001"
+}
+-- post_tool_use_read.json --
+{
+  "session_id": "test-session-123",
+  "transcript_path": "/home/user/.claude/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "permission_mode": "default",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/user/project/README.md"
+  },
+  "tool_response": {
+    "content": "# Project README\n\nThis is the project description.",
+    "success": true
+  },
+  "tool_use_id": "tool-use-003"
+}

--- a/test/acceptance/scripts/hook/protocols/block-matrix.txtar
+++ b/test/acceptance/scripts/hook/protocols/block-matrix.txtar
@@ -1,0 +1,107 @@
+# One block rule, five agent protocols. Every agent must refuse the action
+# through its own wire convention. A wrong exit code or channel silently
+# turns a block into an allow for that agent.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+stdin gemini.json
+execexit 2 gryph _hook gemini BeforeTool
+stdout '"decision":"block"'
+stderr 'blocked-by-acceptance'
+
+stdin opencode.json
+execexit 2 gryph _hook opencode tool.execute.before
+stdout '"decision":"block"'
+
+stdin windsurf.json
+execexit 2 gryph _hook windsurf pre_run_command
+stderr 'blocked-by-acceptance'
+
+stdin piagent.json
+execexit 2 gryph _hook pi-agent tool_call
+stdout '"decision":"block"'
+
+stdin codex.json
+execexit 2 gryph _hook codex PreToolUse
+stdout '"permissionDecision":"deny"'
+
+exec gryph query --status blocked --format json --no-color
+stdout -count=5 '"ResultStatus": "blocked"'
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+  log_all_evaluations: true
+-- home/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: acceptance-block-npm-install
+    action: block
+    severity: high
+    match:
+      action_types: [command_exec]
+      command_patterns:
+        - "(?i)\\bnpm\\s+install\\b"
+    message: "blocked-by-acceptance: npm install is not allowed"
+-- gemini.json --
+{
+  "session_id": "gemini-session-abc",
+  "transcript_path": "/home/user/.gemini/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "BeforeTool",
+  "tool_name": "run_shell_command",
+  "tool_input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  }
+}
+-- opencode.json --
+{
+  "hook_type": "tool.execute.before",
+  "session_id": "opencode-session-abc123",
+  "tool": "bash",
+  "args": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  },
+  "cwd": "/home/user/project"
+}
+-- windsurf.json --
+{
+  "agent_action_name": "pre_run_command",
+  "trajectory_id": "traj-test-123",
+  "execution_id": "exec-003",
+  "timestamp": "2025-01-15T10:32:00Z",
+  "tool_info": {
+    "command_line": "npm install",
+    "cwd": "/home/user/project"
+  }
+}
+-- piagent.json --
+{
+  "session_id": "pi-session-abc",
+  "cwd": "/home/user/project",
+  "hook_event_name": "tool_call",
+  "tool_name": "bash",
+  "tool_call_id": "call-789",
+  "input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  }
+}
+-- codex.json --
+{
+  "session_id": "codex-session-abc",
+  "transcript_path": "/home/user/.codex/transcripts/test.jsonl",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "model": "o4-mini",
+  "turn_id": "turn-001",
+  "tool_name": "Bash",
+  "tool_use_id": "tool-001",
+  "tool_input": {
+    "command": "npm install"
+  }
+}

--- a/test/acceptance/scripts/install/all-agents/files-written.txtar
+++ b/test/acceptance/scripts/install/all-agents/files-written.txtar
@@ -1,0 +1,38 @@
+# One gryph install covers every detected agent and writes each agent's
+# documented file. Uninstall removes every gryph entry and generated file.
+# Cursor detection on Linux needs a cursor binary on PATH, so the script
+# provides a stub. The Cursor assertions run on Linux only.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+mkdir $HOME/.claude
+mkdir $HOME/.cursor
+mkdir $HOME/.gemini
+mkdir $HOME/.codex
+mkdir $HOME/.config/opencode
+mkdir $HOME/.codeium/windsurf
+mkdir $HOME/.pi/agent
+chmod 755 bin/cursor
+env PATH=$WORK/bin${:}$PATH
+
+exec gryph install
+
+grep 'gryph _hook claude-code' $HOME/.claude/settings.json
+grep 'gryph _hook gemini' $HOME/.gemini/settings.json
+grep 'gryph _hook codex' $HOME/.codex/hooks.json
+grep 'gryph _hook windsurf' $HOME/.codeium/windsurf/hooks.json
+grep '"_hook", "opencode"' $HOME/.config/opencode/plugins/gryph.js
+grep '"_hook", "pi-agent"' $HOME/.pi/agent/extensions/gryph-hooks.ts
+[linux] grep 'gryph _hook cursor' $HOME/.cursor/hooks.json
+
+exec gryph uninstall
+
+! grep 'gryph _hook' $HOME/.claude/settings.json
+! grep 'gryph _hook' $HOME/.gemini/settings.json
+! exists $HOME/.config/opencode/plugins/gryph.js
+! exists $HOME/.pi/agent/extensions/gryph-hooks.ts
+
+-- bin/cursor --
+#!/bin/sh
+echo "1.0.0"

--- a/test/acceptance/scripts/install/claude-code/hooks-written.txtar
+++ b/test/acceptance/scripts/install/claude-code/hooks-written.txtar
@@ -1,0 +1,28 @@
+# gryph install writes Claude Code hook entries and keeps what was there.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+exec gryph install --agent claude-code
+
+# gryph hook entries are present for the pre and post phases.
+grep 'gryph _hook claude-code PreToolUse' $HOME/.claude/settings.json
+grep 'gryph _hook claude-code PostToolUse' $HOME/.claude/settings.json
+grep 'gryph _hook claude-code SessionStart' $HOME/.claude/settings.json
+
+# The pre-existing hook and the unrelated setting survive the merge.
+grep 'echo pre-existing-hook' $HOME/.claude/settings.json
+grep '"theme": *"dark"' $HOME/.claude/settings.json
+
+# The database and config directories exist inside the sandbox.
+exists $XDG_DATA_HOME/gryph/audit.db
+
+-- home/.claude/settings.json --
+{
+  "theme": "dark",
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "*", "hooks": [{"type": "command", "command": "echo pre-existing-hook"}]}
+    ]
+  }
+}

--- a/test/acceptance/scripts/install/purge/data-removed.txtar
+++ b/test/acceptance/scripts/install/purge/data-removed.txtar
@@ -1,0 +1,31 @@
+# The purge path removes the database and config. The dry-run previews and
+# changes nothing. Foreign hook entries survive both.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+exec gryph install --agent claude-code
+exec gryph config set logging.level full
+exists $XDG_DATA_HOME/gryph/audit.db
+exists $XDG_CONFIG_HOME/gryph/config.yaml
+
+exec gryph uninstall --purge --dry-run
+exists $XDG_DATA_HOME/gryph/audit.db
+exists $XDG_CONFIG_HOME/gryph/config.yaml
+grep 'gryph _hook' $HOME/.claude/settings.json
+
+exec gryph uninstall --purge
+stdout 'Database and config files have been removed.'
+! exists $XDG_DATA_HOME/gryph/audit.db
+! exists $XDG_CONFIG_HOME/gryph/config.yaml
+! grep 'gryph _hook' $HOME/.claude/settings.json
+grep 'echo pre-existing-hook' $HOME/.claude/settings.json
+
+-- home/.claude/settings.json --
+{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "*", "hooks": [{"type": "command", "command": "echo pre-existing-hook"}]}
+    ]
+  }
+}

--- a/test/acceptance/scripts/install/uninstall/round-trip.txtar
+++ b/test/acceptance/scripts/install/uninstall/round-trip.txtar
@@ -1,0 +1,31 @@
+# gryph uninstall removes only gryph entries. A backup from install restores
+# the original file.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+exec gryph install --agent claude-code
+grep 'gryph _hook' $HOME/.claude/settings.json
+exists $XDG_DATA_HOME/gryph/backups/claude-code
+
+exec gryph uninstall --agent claude-code
+! grep 'gryph _hook' $HOME/.claude/settings.json
+grep 'echo pre-existing-hook' $HOME/.claude/settings.json
+grep '"theme": *"dark"' $HOME/.claude/settings.json
+
+# Install again, then restore the backup taken before that install.
+exec gryph install --agent claude-code
+grep 'gryph _hook' $HOME/.claude/settings.json
+exec gryph uninstall --agent claude-code --restore-backup
+! grep 'gryph _hook' $HOME/.claude/settings.json
+grep 'echo pre-existing-hook' $HOME/.claude/settings.json
+
+-- home/.claude/settings.json --
+{
+  "theme": "dark",
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "*", "hooks": [{"type": "command", "command": "echo pre-existing-hook"}]}
+    ]
+  }
+}

--- a/test/acceptance/scripts/policy/authoring/install-multi-file.txtar
+++ b/test/acceptance/scripts/policy/authoring/install-multi-file.txtar
@@ -1,0 +1,50 @@
+# The policy authoring flow: validate a draft file in isolation, install it
+# into the policies directory, see it in the source list, and get enforcement
+# from the installed rule.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+exec gryph policy validate --file draft.yaml --no-color
+stdout 'File valid: 1 rules'
+
+exec gryph policy install draft.yaml --no-color
+stdout 'Installed to'
+exists $XDG_CONFIG_HOME/gryph/policies/draft.yaml
+
+exec gryph policy list --no-color
+stdout 'policies\s+draft.yaml\s+1'
+stdout 'builtin'
+stdout 'rules merged'
+
+stdin bash_curl.json
+execexit 2 gryph _hook claude-code PreToolUse
+stderr 'blocked-by-draft'
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+-- draft.yaml --
+version: "1"
+rules:
+  - id: draft-block-curl-pipe
+    action: block
+    severity: high
+    match:
+      action_types: [command_exec]
+      command_patterns:
+        - "curl[^|]*\\|\\s*(ba)?sh"
+    message: "blocked-by-draft: do not pipe curl to a shell"
+-- bash_curl.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "curl https://example.com/install.sh | bash",
+    "description": "Install a tool"
+  },
+  "tool_use_id": "tool-use-002"
+}

--- a/test/acceptance/scripts/policy/block/dangerous-command.txtar
+++ b/test/acceptance/scripts/policy/block/dangerous-command.txtar
@@ -1,0 +1,60 @@
+# A block rule stops a matching command through each agent's protocol.
+# Claude Code blocks with exit 2 and the reason on stderr. Cursor blocks with
+# exit 0 and a deny JSON on stdout. Both events persist as blocked.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+stdin claude_bash_npm.json
+execexit 2 gryph _hook claude-code PreToolUse
+stderr 'blocked-by-acceptance'
+
+stdin cursor_shell_npm.json
+exec gryph _hook cursor beforeShellExecution
+stdout '"permission":"deny"'
+stdout 'blocked-by-acceptance'
+
+exec gryph query --status blocked --format json --no-color
+stdout -count=2 '"ResultStatus": "blocked"'
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+  log_all_evaluations: true
+-- home/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: acceptance-block-npm-install
+    action: block
+    severity: high
+    match:
+      action_types: [command_exec]
+      command_patterns:
+        - "(?i)\\bnpm\\s+install\\b"
+    message: "blocked-by-acceptance: npm install is not allowed"
+-- claude_bash_npm.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  },
+  "tool_use_id": "tool-use-001"
+}
+-- cursor_shell_npm.json --
+{
+  "conversation_id": "conv-test-123",
+  "generation_id": "gen-005",
+  "model": "claude-3-opus",
+  "hook_event_name": "beforeShellExecution",
+  "cursor_version": "0.44.0",
+  "workspace_roots": ["/home/user/project"],
+  "user_email": "user@example.com",
+  "command": "npm install",
+  "cwd": "/home/user/project",
+  "timeout": 30000
+}

--- a/test/acceptance/scripts/policy/defer/timeout-resolves-deny.txtar
+++ b/test/acceptance/scripts/policy/defer/timeout-resolves-deny.txtar
@@ -1,0 +1,77 @@
+# A deferred action never rots into an allow. A human resolves it with a
+# decision, or the sweep resolves an expired one to deny.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+# Resolve path: long timeout, human denies.
+stdin bash_npm.json
+execexit 2 gryph _hook claude-code PreToolUse
+stderr 'Action deferred'
+stderr 'deferrals resolve'
+
+exec gryph policy deferrals --format json --no-color
+stdout '"status": "pending"'
+capture DEFER_ID '"id": "([0-9a-f-]+)"'
+exec gryph policy deferrals resolve --id $DEFER_ID --decision deny --note acceptance
+exec gryph policy deferrals --status resolved_deny --format json --no-color
+stdout '"status": "resolved_deny"'
+
+# Sweep path: one-second timeout, the sweep resolves the expired row to
+# timeout, which is a deny.
+env XDG_CONFIG_HOME=$WORK/home2/.config
+env XDG_DATA_HOME=$WORK/home2/.local/share
+stdin bash_npm.json
+execexit 2 gryph _hook claude-code PreToolUse
+exec sleep 2
+exec gryph policy deferrals sweep --no-color
+stdout 'Swept 1 expired'
+exec gryph policy deferrals --status resolved_timeout --format json --no-color
+stdout '"status": "resolved_timeout"'
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+  defer:
+    enabled: true
+    timeout_seconds: 600
+-- home/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: acceptance-defer-npm
+    action: defer
+    reason: "needs human review"
+    match:
+      action_types: [command_exec]
+      command_patterns:
+        - "(?i)\\bnpm\\s+install\\b"
+-- home2/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+  defer:
+    enabled: true
+    timeout_seconds: 1
+-- home2/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: acceptance-defer-npm
+    action: defer
+    reason: "needs human review"
+    match:
+      action_types: [command_exec]
+      command_patterns:
+        - "(?i)\\bnpm\\s+install\\b"
+-- bash_npm.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  },
+  "tool_use_id": "tool-use-001"
+}

--- a/test/acceptance/scripts/policy/fail-mode/closed-on-broken-policy.txtar
+++ b/test/acceptance/scripts/policy/fail-mode/closed-on-broken-policy.txtar
@@ -1,0 +1,50 @@
+# A broken policy must never silently turn Gryph off. With fail_mode closed
+# the hook blocks and a policy_load_error self-audit row exists. With
+# fail_mode open the same broken policy lets the action through.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+stdin bash_npm.json
+execexit 2 gryph _hook claude-code PreToolUse
+stderr 'policy load failed'
+
+exec gryph self-log --format json --no-color
+stdout '"Action": "policy_load_error"'
+
+# The same broken policy under fail_mode open allows the action.
+env XDG_CONFIG_HOME=$WORK/home2/.config
+env XDG_DATA_HOME=$WORK/home2/.local/share
+stdin bash_npm.json
+exec gryph _hook claude-code PreToolUse
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+-- home/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: broken-rule
+    action: nosuchdecision
+-- home2/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: open
+-- home2/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: broken-rule
+    action: nosuchdecision
+-- bash_npm.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  },
+  "tool_use_id": "tool-use-001"
+}

--- a/test/acceptance/scripts/policy/guidance/advisory-delivered.txtar
+++ b/test/acceptance/scripts/policy/guidance/advisory-delivered.txtar
@@ -1,0 +1,57 @@
+# A guidance rule advises without blocking. Claude Code gets the advisory on
+# stderr at exit 0. Cursor gets an allow with a user_message. The event
+# persists as success, not blocked.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+stdin claude_read.json
+exec gryph _hook claude-code PreToolUse
+stderr 'guidance-advisory'
+
+stdin cursor_read.json
+exec gryph _hook cursor beforeReadFile
+stdout '"permission":"allow"'
+stdout 'guidance-advisory'
+
+exec gryph query --format json --no-color
+stdout -count=2 '"ResultStatus": "success"'
+! stdout '"ResultStatus": "blocked"'
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+-- home/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: acceptance-guide-readme
+    action: guidance
+    severity: medium
+    match:
+      action_types: [file_read]
+      file_patterns:
+        - "**/README.md"
+    message: "guidance-advisory: read the docs index first"
+-- claude_read.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/user/project/README.md"
+  },
+  "tool_use_id": "tool-use-004"
+}
+-- cursor_read.json --
+{
+  "conversation_id": "conv-test-123",
+  "generation_id": "gen-006",
+  "model": "claude-3-opus",
+  "hook_event_name": "beforeReadFile",
+  "cursor_version": "0.44.0",
+  "workspace_roots": ["/home/user/project"],
+  "user_email": "user@example.com",
+  "file_path": "/home/user/project/README.md"
+}

--- a/test/acceptance/scripts/policy/self-protection/config-write-blocked.txtar
+++ b/test/acceptance/scripts/policy/self-protection/config-write-blocked.txtar
@@ -1,0 +1,48 @@
+# The builtin self-protection rules block agent writes to gryph control files
+# and to agent hook configuration. No user policy file is present, so only the
+# builtin rules can fire.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+expandenv write_policy.json write_hookcfg.json
+
+stdin write_policy.json
+execexit 2 gryph _hook claude-code PreToolUse
+stderr 'self-protection'
+
+stdin write_hookcfg.json
+execexit 2 gryph _hook claude-code PreToolUse
+stderr 'self-protection'
+
+exec gryph query --status blocked --format json --no-color
+stdout -count=2 '"ResultStatus": "blocked"'
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+-- write_policy.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "${XDG_CONFIG_HOME}/gryph/policy.yaml",
+    "content": "version: \"1\"\nrules: []\n"
+  },
+  "tool_use_id": "tool-use-sp1"
+}
+-- write_hookcfg.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "${HOME}/.claude/settings.json",
+    "content": "{}"
+  },
+  "tool_use_id": "tool-use-sp2"
+}

--- a/test/acceptance/scripts/privacy/sensitive/content-never-stored.txtar
+++ b/test/acceptance/scripts/privacy/sensitive/content-never-stored.txtar
@@ -1,0 +1,47 @@
+# A write to a sensitive path is flagged. Its content never reaches storage,
+# even at logging level full. Export excludes the event unless --sensitive is
+# set, and even then never carries the content.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+expandenv write_env.json
+
+stdin write_env.json
+exec gryph _hook claude-code PostToolUse
+
+exec gryph query --sensitive --format json --no-color
+stdout '"IsSensitive": true'
+stdout '\.env'
+! stdout 'SUPERSECRET123VALUE'
+! stdout 'hunter2'
+
+# The only event is sensitive, so a default export is empty.
+exec gryph export --since 1h
+stderr 'No events to export.'
+
+# --sensitive includes the event but never its content.
+exec gryph export --since 1h --sensitive
+stdout '"is_sensitive":true'
+! stdout 'SUPERSECRET123VALUE'
+! stdout 'hunter2'
+stderr 'Exported 1 events'
+
+-- home/.config/gryph/config.yaml --
+logging:
+  level: full
+-- write_env.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "${WORK}/home/project",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "${WORK}/home/project/.env",
+    "content": "api_key=SUPERSECRET123VALUE\npassword=hunter2"
+  },
+  "tool_response": {
+    "success": true
+  },
+  "tool_use_id": "tool-use-sens"
+}

--- a/test/acceptance/scripts/receipts/signing/key-round-trip.txtar
+++ b/test/acceptance/scripts/receipts/signing/key-round-trip.txtar
@@ -1,0 +1,68 @@
+# With a generated key, receipts come out signed and the offline verifier
+# validates them against the trust store. A tampered signature is detected
+# and fails verification.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+exec gryph policy keys generate --no-color
+stdout 'Generated key'
+exists $XDG_CONFIG_HOME/gryph/keys/receipt.key
+exists $XDG_CONFIG_HOME/gryph/keys/receipt-pub.json
+
+stdin read_allow.json
+exec gryph _hook claude-code PreToolUse
+stdin bash_npm.json
+execexit 2 gryph _hook claude-code PreToolUse
+
+exec gryph policy receipts export --format jsonl --include-signatures --output signed.jsonl
+exec gryph policy receipts verify-log --input signed.jsonl --no-color
+stdout 'signed_ok\s+2'
+stdout 'signed_invalid\s+0'
+stdout 'chain_breaks\s+0'
+
+capture SIG '"signature":"([A-Za-z0-9+/=]+)"' signed.jsonl
+replace signed.jsonl $SIG AAAA$SIG
+execexit 2 gryph policy receipts verify-log --input signed.jsonl --no-color
+stdout 'signed_invalid\s+1'
+stderr 'invalid signature'
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+  log_all_evaluations: true
+-- home/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: acceptance-block-npm-install
+    action: block
+    severity: high
+    match:
+      action_types: [command_exec]
+      command_patterns:
+        - "(?i)\\bnpm\\s+install\\b"
+    message: "blocked-by-acceptance"
+-- read_allow.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/user/project/main.go"
+  },
+  "tool_use_id": "tool-use-r1"
+}
+-- bash_npm.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  },
+  "tool_use_id": "tool-use-r2"
+}

--- a/test/acceptance/scripts/receipts/verify-log/tamper-fails.txtar
+++ b/test/acceptance/scripts/receipts/verify-log/tamper-fails.txtar
@@ -1,0 +1,77 @@
+# Receipts export to JSONL and verify offline. Verification passes on the
+# untampered log and fails with a non-zero exit after one field changes.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+stdin read_allow.json
+exec gryph _hook claude-code PreToolUse
+
+stdin bash_npm_block.json
+execexit 2 gryph _hook claude-code PreToolUse
+
+stdin post_read_allow.json
+exec gryph _hook claude-code PostToolUse
+
+exec gryph policy receipts export --format jsonl --output receipts.jsonl
+exec gryph policy receipts verify-log --input receipts.jsonl
+stdout 'chain_breaks\s+0'
+
+replace receipts.jsonl '"decision":"block"' '"decision":"allow"'
+execexit 2 gryph policy receipts verify-log --input receipts.jsonl
+stderr 'chain break'
+
+-- home/.config/gryph/config.yaml --
+policy:
+  enabled: true
+  fail_mode: closed
+  log_all_evaluations: true
+-- home/.config/gryph/policy.yaml --
+version: "1"
+rules:
+  - id: acceptance-block-npm-install
+    action: block
+    severity: high
+    match:
+      action_types: [command_exec]
+      command_patterns:
+        - "(?i)\\bnpm\\s+install\\b"
+    message: "blocked-by-acceptance: npm install is not allowed"
+-- read_allow.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/user/project/README.md"
+  },
+  "tool_use_id": "tool-use-r1"
+}
+-- bash_npm_block.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "npm install",
+    "description": "Install dependencies"
+  },
+  "tool_use_id": "tool-use-r2"
+}
+-- post_read_allow.json --
+{
+  "session_id": "test-session-123",
+  "cwd": "/home/user/project",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/user/project/README.md"
+  },
+  "tool_response": {
+    "content": "# Project README",
+    "success": true
+  },
+  "tool_use_id": "tool-use-r3"
+}


### PR DESCRIPTION
## What

Add `test/acceptance/`, a `testscript`-driven suite that runs the real `gryph` binary in a sandboxed HOME and checks user-facing contracts. Each guarantee is one txtar script plus one `catalog.yaml` row with a tier. `TestCatalogIntegrity` runs under normal `go test ./...` and fails when a script has no catalog row. CI runs the suite as a new `acceptance` job on every pull request and push to main. The suite is hermetic, so it gates.

Ten seed guarantees:

| id | tier | guarantee |
| --- | --- | --- |
| install/claude-code/hooks-written | P0 | install adds gryph hooks and keeps foreign entries |
| install/uninstall/round-trip | P0 | uninstall removes only gryph hooks, backup restores |
| hook/ingest/event-persisted | P0 | a hook payload becomes a queryable event in one session |
| policy/block/dangerous-command | P0 | block exits 2 with reason (Claude Code), deny JSON at exit 0 (Cursor) |
| policy/self-protection/config-write-blocked | P0 | builtin rules block writes to gryph and hook config |
| privacy/sensitive/content-never-stored | P0 | sensitive content never reaches storage or export |
| receipts/verify-log/tamper-fails | P1 | verify-log passes clean export, fails tampered export |
| export/schema/jsonl-stable | P1 | export emits schema-tagged JSONL, summary on stderr |
| errors/exit-codes/contract | P1 | exit codes 0, 2, 3, 4 hold on the real binary |
| health/status-doctor/healthy | P1 | status and doctor report a healthy install |

`test/cli` (in-process) and `test/conformance/aarm` (spec) stay separate and do not overlap.

## Bug found and fixed

The receipts script caught a real defect: every allow receipt failed chain verification after a database or export round trip. The consensus format hashes `matched_rule_ids` as `null` when the list is empty, but the PDP hands an empty non-nil slice, so the insert path hashed `[]`. Storage persists the empty list as NULL, so verification always recomputed `null` and broke. `NewHashInput` now normalizes nil and empty to `null`. Every hash and verify path goes through it. A regression test pins the normalization.

Rows written before this fix with an empty rule list keep their `[]`-based hash and still fail verification. Blocked rows and rows with matched rules are not affected.

## Docs

- `docs/cli-reference.md`: remove the `query --show-diff` and `export --format` flags (the code does not have them), document the real `logs`, `query`, and `export` flags, add `cat`, `cost`, and `stats` sections.
- `README.md`: remove the `query --show-diff` example.
- `AGENTS.md`: describe the acceptance suite and the one-script-one-row rule.

## Validation

- `go test ./...` passes (integrity test included).
- `go test -tags acceptance ./test/acceptance/` passes, ~3s including the binary build.
- `make lint` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RaL2uKT8BMKWogVDzFk8T

---
_Generated by [Claude Code](https://claude.ai/code/session_017RaL2uKT8BMKWogVDzFk8T)_