### PR TITLE
Move state to the safedep/gryph namespace with PMG-style controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ tui/            Output formatters (table, json, csv)
 ## Notes
 
 - SQLite driver: `modernc.org/sqlite` (pure Go, uses `sqlite` not `sqlite3`)
-- Config paths: macOS `~/Library/Application Support/gryph/`, Linux `~/.config/gryph/`
+- Config paths: macOS `~/Library/Application Support/safedep/gryph/`, Linux `~/.config/safedep/gryph/`. Overrides: `GRYPH_CONFIG_DIR`, `GRYPH_DATA_DIR`, `GRYPH_CACHE_DIR`
 - Storage layer fully implemented with ent ORM
 - Self-audit logs tool actions (install, uninstall, config changes)
 

--- a/README.md
+++ b/README.md
@@ -294,9 +294,9 @@ Existing files are automatically backed up before modification. Backups are stor
 
 | Platform | Backup Location |
 | --- | --- |
-| macOS | `~/Library/Application Support/gryph/backups/` |
-| Linux | `~/.local/share/gryph/backups/` |
-| Windows | `%LOCALAPPDATA%\gryph\backups\` |
+| macOS | `~/Library/Application Support/safedep/gryph/backups/` |
+| Linux | `~/.local/share/safedep/gryph/backups/` |
+| Windows | `%LOCALAPPDATA%\safedep\gryph\backups\` |
 
 Backup files are named with timestamps (e.g., `settings.json.backup.20250131120000`).
 

--- a/cli/audit.go
+++ b/cli/audit.go
@@ -45,6 +45,7 @@ const (
 	SelfAuditActionDeferralSweep           = "deferral_sweep"
 	SelfAuditActionDeferralCleanup         = "deferral_cleanup"
 	SelfAuditActionIdentityMissing         = "identity_missing"
+	SelfAuditActionPathMigration           = "path_migration"
 	SelfAuditResultSuccess                 = "success"
 	SelfAuditResultError                   = "error"
 	SelfAuditResultSkipped                 = "skipped"

--- a/cli/config.go
+++ b/cli/config.go
@@ -20,6 +20,22 @@ func resolveConfigPath(app *App) string {
 	return app.Paths.ConfigFile
 }
 
+// refuseWhenManaged blocks per-user config writes while the system managed
+// config file is active, because the per-user file is ignored at load time
+// and the write would silently do nothing. An explicit --config path still
+// wins, so a write to a named file stays possible.
+func refuseWhenManaged() error {
+	if globalFlags.ConfigPath != "" {
+		return nil
+	}
+
+	if managed := config.ManagedConfigFile(); managed != "" {
+		return fmt.Errorf("configuration is managed by %s: contact your administrator to change it", managed)
+	}
+
+	return nil
+}
+
 func NewConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
@@ -120,6 +136,10 @@ func newConfigSetCmd() *cobra.Command {
 			key := args[0]
 			value := args[1]
 
+			if err := refuseWhenManaged(); err != nil {
+				return err
+			}
+
 			app, err := loadApp()
 			if err != nil {
 				return err
@@ -175,6 +195,10 @@ func newConfigResetCmd() *cobra.Command {
 		Short: "Reset to default configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+
+			if err := refuseWhenManaged(); err != nil {
+				return err
+			}
 
 			app, err := loadApp()
 			if err != nil {

--- a/cli/config.go
+++ b/cli/config.go
@@ -10,11 +10,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// resolveConfigPath returns the config file path, preferring the --config flag
-// over the platform default.
+// resolveConfigPath returns the config file path for the config commands:
+// the --config flag, then the active managed file, then the per-user file.
+// This keeps config show and config get on the effective file. The write
+// commands refuse before they reach the managed file.
 func resolveConfigPath(app *App) string {
 	if globalFlags.ConfigPath != "" {
 		return globalFlags.ConfigPath
+	}
+
+	if managed := config.ManagedConfigFile(); managed != "" {
+		return managed
 	}
 
 	return app.Paths.ConfigFile

--- a/cli/config.go
+++ b/cli/config.go
@@ -11,30 +11,25 @@ import (
 )
 
 // resolveConfigPath returns the config file path for the config commands:
-// the --config flag, then the active managed file, then the per-user file.
+// the active managed file, then the --config flag, then the per-user file.
 // This keeps config show and config get on the effective file. The write
 // commands refuse before they reach the managed file.
 func resolveConfigPath(app *App) string {
-	if globalFlags.ConfigPath != "" {
-		return globalFlags.ConfigPath
-	}
-
 	if managed := config.ManagedConfigFile(); managed != "" {
 		return managed
+	}
+
+	if globalFlags.ConfigPath != "" {
+		return globalFlags.ConfigPath
 	}
 
 	return app.Paths.ConfigFile
 }
 
-// refuseWhenManaged blocks per-user config writes while the system managed
-// config file is active, because the per-user file is ignored at load time
-// and the write would silently do nothing. An explicit --config path still
-// wins, so a write to a named file stays possible.
+// refuseWhenManaged blocks config writes while the system managed config
+// file is active. The managed file is authoritative over --config and the
+// per-user file, so any other write would silently do nothing.
 func refuseWhenManaged() error {
-	if globalFlags.ConfigPath != "" {
-		return nil
-	}
-
 	if managed := config.ManagedConfigFile(); managed != "" {
 		return fmt.Errorf("configuration is managed by %s: contact your administrator to change it", managed)
 	}

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/safedep/dry/log"
+	"github.com/safedep/gryph/config"
 	"github.com/safedep/gryph/internal/selfupdate"
 	"github.com/safedep/gryph/internal/version"
 	"github.com/safedep/gryph/tui"
@@ -64,7 +65,10 @@ Performs various health checks:
 					Name:        "Config file",
 					Description: "Check if config file exists and is valid",
 				}
-				if _, err := os.Stat(app.Paths.ConfigFile); os.IsNotExist(err) {
+				if managed := config.ManagedConfigFile(); managed != "" {
+					configCheck.Status = tui.CheckOK
+					configCheck.Message = managed + " (managed by the system)"
+				} else if _, err := os.Stat(app.Paths.ConfigFile); os.IsNotExist(err) {
 					configCheck.Status = tui.CheckWarn
 					configCheck.Message = "Config file not found (using defaults)"
 					configCheck.Suggestion = "Run 'gryph config set' to create"

--- a/cli/policy_authoring_test.go
+++ b/cli/policy_authoring_test.go
@@ -30,7 +30,7 @@ func writePolicyFile(t *testing.T, path, body string) {
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
 }
 
-func gryphConfigDir(root string) string { return filepath.Join(root, "gryph") }
+func gryphConfigDir(root string) string { return filepath.Join(root, "safedep", "gryph") }
 
 func TestResolvePolicyTarget(t *testing.T) {
 	paths := &config.Paths{ConfigDir: "/cfg"}

--- a/cli/root.go
+++ b/cli/root.go
@@ -131,7 +131,29 @@ func (a *App) InitStore(ctx context.Context) error {
 		return err
 	}
 	a.Store = store
+	a.recordPathMigration(ctx)
 	return nil
+}
+
+// recordPathMigration writes the self-audit entry for a completed layout
+// migration. The migration runs in the config package before any store
+// exists, so the record arrives through a marker file that the first
+// store-opening command consumes.
+func (a *App) recordPathMigration(ctx context.Context) {
+	record := config.ConsumeMigrationMarker()
+	if record == nil {
+		return
+	}
+
+	details := map[string]interface{}{"moves": record.Moves}
+	if len(record.Warnings) > 0 {
+		details["warnings"] = record.Warnings
+	}
+
+	if err := logSelfAudit(ctx, a.Store, SelfAuditActionPathMigration, "", details,
+		SelfAuditResultSuccess, ""); err != nil {
+		log.Warnf("failed to log path migration self-audit: %v", err)
+	}
 }
 
 // Close closes the application resources.

--- a/config/config.go
+++ b/config/config.go
@@ -282,7 +282,12 @@ type Paths struct {
 }
 
 // Load loads configuration from the given path or default locations.
+//
+// Precedence: an explicit configPath wins, then the system managed file,
+// then the per-user config file.
 func Load(configPath string) (*Config, error) {
+	MigrateLegacyLayout()
+
 	v := viper.New()
 
 	// Set defaults
@@ -292,8 +297,11 @@ func Load(configPath string) (*Config, error) {
 	v.SetConfigType("yaml")
 
 	// Determine config file path
+	managed := ""
 	if configPath != "" {
 		v.SetConfigFile(configPath)
+	} else if managed = ManagedConfigFile(); managed != "" {
+		v.SetConfigFile(managed)
 	} else {
 		paths := ResolvePaths()
 
@@ -309,6 +317,11 @@ func Load(configPath string) (*Config, error) {
 	// Read config file
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			// A broken managed file makes the caller fall back to defaults.
+			// Name the file so the administrator can find it.
+			if managed != "" {
+				log.Warnf("failed to read managed config %s: %v", managed, err)
+			}
 			return nil, fmt.Errorf("error reading config file: %w", err)
 		}
 	}
@@ -405,7 +418,7 @@ func ResolvePaths() *Paths {
 	cacheDir := getCacheDir()
 
 	return &Paths{
-		ConfigFile:   filepath.Join(configDir, "config.yaml"),
+		ConfigFile:   filepath.Join(configDir, configFileName),
 		ConfigDir:    configDir,
 		DataDir:      dataDir,
 		DatabaseFile: filepath.Join(dataDir, "audit.db"),

--- a/config/config.go
+++ b/config/config.go
@@ -283,8 +283,10 @@ type Paths struct {
 
 // Load loads configuration from the given path or default locations.
 //
-// Precedence: an explicit configPath wins, then the system managed file,
-// then the per-user config file.
+// Precedence: the system managed file is authoritative when present. It
+// wins over an explicit configPath and over the per-user config file, so a
+// user cannot bypass it with --config. Without a managed file, an explicit
+// configPath wins over the per-user file.
 func Load(configPath string) (*Config, error) {
 	MigrateLegacyLayout()
 
@@ -298,10 +300,10 @@ func Load(configPath string) (*Config, error) {
 
 	// Determine config file path
 	managed := ""
-	if configPath != "" {
-		v.SetConfigFile(configPath)
-	} else if managed = ManagedConfigFile(); managed != "" {
+	if managed = ManagedConfigFile(); managed != "" {
 		v.SetConfigFile(managed)
+	} else if configPath != "" {
+		v.SetConfigFile(configPath)
 	} else {
 		paths := ResolvePaths()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -388,61 +388,9 @@ func TestResolvePaths(t *testing.T) {
 	assert.NotEmpty(t, paths.CacheDir)
 	assert.NotEmpty(t, paths.BackupsDir)
 
-	assert.Contains(t, paths.ConfigFile, "config.yaml")
+	assert.Contains(t, paths.ConfigFile, "config.yml")
 	assert.Contains(t, paths.DatabaseFile, "audit.db")
 	assert.Contains(t, paths.BackupsDir, "backups")
-}
-
-func TestGetConfigDir_XDGConfigHomeHonored(t *testing.T) {
-	// XDG_CONFIG_HOME must be respected on every platform, not just Linux.
-	// Go's os.UserConfigDir honors it on Linux but returns
-	// ~/Library/Application Support on macOS and %AppData% on Windows,
-	// so this behaviour has to be explicit in gryph.
-	tmpDir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
-
-	got := getConfigDir()
-	assert.Equal(t, filepath.Join(tmpDir, "gryph"), got)
-}
-
-func TestGetConfigDir_PrefersExistingXDGConfigDir(t *testing.T) {
-	// When XDG_CONFIG_HOME is unset but the user has opted into the XDG
-	// layout by creating ~/.config/gryph, prefer that over the platform
-	// default (macOS: ~/Library/Application Support, Windows: %AppData%).
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
-	t.Setenv("XDG_CONFIG_HOME", "")
-
-	xdgConfig := filepath.Join(tmpHome, ".config", "gryph")
-	require.NoError(t, os.MkdirAll(xdgConfig, 0o700))
-
-	got := getConfigDir()
-	assert.Equal(t, xdgConfig, got)
-}
-
-func TestGetDataDir_XDGDataHomeHonored(t *testing.T) {
-	// Same rationale as XDG_CONFIG_HOME: the previous implementation only
-	// consulted XDG_DATA_HOME on Linux. Respect it on macOS and Windows too.
-	tmpDir := t.TempDir()
-	t.Setenv("XDG_DATA_HOME", tmpDir)
-
-	got := getDataDir()
-	assert.Equal(t, filepath.Join(tmpDir, "gryph"), got)
-}
-
-func TestGetDataDir_PrefersExistingXDGDataDir(t *testing.T) {
-	// Without XDG_DATA_HOME, if ~/.local/share/gryph already exists the
-	// user has opted into the XDG layout and we return that path on every
-	// platform. Without the directory, platform defaults still apply.
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
-	t.Setenv("XDG_DATA_HOME", "")
-
-	xdgData := filepath.Join(tmpHome, ".local", "share", "gryph")
-	require.NoError(t, os.MkdirAll(xdgData, 0o700))
-
-	got := getDataDir()
-	assert.Equal(t, xdgData, got)
 }
 
 func TestEnsureDirectories(t *testing.T) {

--- a/config/manager.go
+++ b/config/manager.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/safedep/dry/log"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
@@ -67,7 +68,23 @@ func (m *Manager) Set(key string, value interface{}) error {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 
+	m.removeStaleLegacyConfig()
+
 	return nil
+}
+
+// removeStaleLegacyConfig deletes a config.yaml sibling after a write to
+// config.yml. Viper prefers the yaml extension, so a stale sibling would
+// shadow every later read of the written file.
+func (m *Manager) removeStaleLegacyConfig() {
+	if filepath.Base(m.configPath) != configFileName {
+		return
+	}
+
+	stale := filepath.Join(filepath.Dir(m.configPath), legacyConfigFileName)
+	if err := os.Remove(stale); err != nil && !os.IsNotExist(err) {
+		log.Warnf("failed to remove stale %s: %v", stale, err)
+	}
 }
 
 // Reset removes the config file, effectively resetting to defaults.

--- a/config/manager_test.go
+++ b/config/manager_test.go
@@ -293,3 +293,16 @@ func TestManager_Set_MultipleValues(t *testing.T) {
 	assert.Equal(t, 30, newMgr.Get("storage.retention_days"))
 	assert.Equal(t, "always", newMgr.Get("display.colors"))
 }
+
+func TestManagerSet_RemovesStaleLegacyConfig(t *testing.T) {
+	dir := t.TempDir()
+	stale := filepath.Join(dir, legacyConfigFileName)
+	require.NoError(t, os.WriteFile(stale, []byte("logging:\n  level: full\n"), 0o600))
+
+	mgr, err := NewManager(filepath.Join(dir, configFileName))
+	require.NoError(t, err)
+	require.NoError(t, mgr.Set("logging.level", "minimal"))
+
+	assert.FileExists(t, filepath.Join(dir, configFileName))
+	assert.NoFileExists(t, stale)
+}

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/safedep/dry/log"
+)
+
+const (
+	legacyLeaf           = "gryph"
+	legacyConfigFileName = "config.yaml"
+	migrationMarkerName  = "migration.json"
+)
+
+// MigrationMove records one directory move performed by the migration.
+type MigrationMove struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// MigrationRecord describes a completed layout migration. It is handed to
+// the CLI through a marker file, so the self-audit entry can be written by
+// whichever later process opens the store first.
+type MigrationRecord struct {
+	Moves    []MigrationMove `json:"moves"`
+	Warnings []string        `json:"warnings,omitempty"`
+}
+
+var migrateOnce sync.Once
+
+// MigrateLegacyLayout moves the pre safedep/gryph directory tree to the new
+// layout, once per install. The fast path is a few stat calls. Failures
+// never stop the caller: gryph runs in the agent hook path and a migration
+// problem must not break the agent.
+func MigrateLegacyLayout() {
+	migrateOnce.Do(migrateLegacyLayout)
+}
+
+func migrateLegacyLayout() {
+	// An elevated run must not move the invoking user's files. The next
+	// non-elevated run migrates them.
+	if isSudoElevation() {
+		return
+	}
+
+	record := MigrationRecord{}
+
+	// The cache directory is not migrated: gryph stores nothing in it. Only
+	// config and data move, and on macOS those resolve to one pair.
+	kinds := []struct {
+		envKey string
+		legacy string
+		target string
+	}{
+		{configDirEnvKey, legacyConfigDir(), getConfigDir()},
+		{dataDirEnvKey, legacyDataDir(), getDataDir()},
+	}
+
+	seen := map[string]bool{}
+	for _, kind := range kinds {
+		if os.Getenv(kind.envKey) != "" {
+			continue
+		}
+		pair := kind.legacy + "\x00" + kind.target
+		if kind.legacy == kind.target || seen[pair] {
+			continue
+		}
+		seen[pair] = true
+
+		moved, warning := moveLegacyDir(kind.legacy, kind.target)
+		if moved {
+			record.Moves = append(record.Moves, MigrationMove{From: kind.legacy, To: kind.target})
+		}
+		if warning != "" {
+			record.Warnings = append(record.Warnings, warning)
+		}
+	}
+
+	if os.Getenv(cacheDirEnvKey) == "" {
+		// EnsureDirectories created the legacy cache directory empty, so a
+		// plain remove clears it. os.Remove refuses a non-empty directory.
+		if err := os.Remove(legacyCacheDir()); err != nil && !os.IsNotExist(err) {
+			log.Debugf("config migration: legacy cache directory not removed: %v", err)
+		}
+	}
+
+	normalizeConfigFileName(getConfigDir())
+
+	if len(record.Moves) > 0 {
+		writeMigrationMarker(record)
+	}
+}
+
+// moveLegacyDir renames legacy to target when only legacy exists. It
+// returns whether the move happened and a warning for the self-audit record.
+func moveLegacyDir(legacy, target string) (bool, string) {
+	if _, err := os.Stat(legacy); err != nil {
+		return false, ""
+	}
+	if _, err := os.Stat(target); err == nil {
+		warning := fmt.Sprintf("legacy directory %s and new directory %s both exist: gryph uses the new directory, reconcile and remove the legacy one by hand", legacy, target)
+		log.Warnf("config migration: %s", warning)
+		return false, warning
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		log.Warnf("config migration: failed to create %s: %v", filepath.Dir(target), err)
+		return false, ""
+	}
+	if err := os.Rename(legacy, target); err != nil {
+		// A concurrent gryph process can win the rename. Its result is the
+		// same, so a vanished legacy directory is not a failure.
+		if os.IsNotExist(err) {
+			return false, ""
+		}
+		log.Warnf("config migration: failed to move %s to %s, move it by hand: %v", legacy, target, err)
+		return false, ""
+	}
+	return true, ""
+}
+
+// normalizeConfigFileName renames config.yaml to config.yml in configDir.
+// Viper prefers the yaml extension, so the two names must never coexist or
+// writes to config.yml would be shadowed by a stale config.yaml.
+func normalizeConfigFileName(configDir string) {
+	legacy := filepath.Join(configDir, legacyConfigFileName)
+	target := filepath.Join(configDir, configFileName)
+
+	if _, err := os.Stat(legacy); err != nil {
+		return
+	}
+	if _, err := os.Stat(target); err == nil {
+		return
+	}
+	if err := os.Rename(legacy, target); err != nil && !os.IsNotExist(err) {
+		log.Warnf("config migration: failed to rename %s to %s: %v", legacy, target, err)
+	}
+}
+
+// Legacy resolvers reproduce the pre safedep/gryph resolution, including the
+// XDG preference on every platform and the preexisting-directory checks.
+// They are the only source of legacy paths.
+
+func legacyConfigDir() string {
+	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
+		return filepath.Join(xdgConfig, legacyLeaf)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		xdgDefault := filepath.Join(home, ".config", legacyLeaf)
+		if info, err := os.Stat(xdgDefault); err == nil && info.IsDir() {
+			return xdgDefault
+		}
+	}
+	return filepath.Join(configBaseDir(), legacyLeaf)
+}
+
+func legacyDataDir() string {
+	if xdgData := os.Getenv("XDG_DATA_HOME"); xdgData != "" {
+		return filepath.Join(xdgData, legacyLeaf)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		xdgDefault := filepath.Join(home, ".local", "share", legacyLeaf)
+		if info, err := os.Stat(xdgDefault); err == nil && info.IsDir() {
+			return xdgDefault
+		}
+	}
+	return filepath.Join(dataBaseDir(), legacyLeaf)
+}
+
+func legacyCacheDir() string {
+	return filepath.Join(cacheBaseDir(), legacyLeaf)
+}
+
+func migrationMarkerPath() string {
+	return filepath.Join(getDataDir(), migrationMarkerName)
+}
+
+func writeMigrationMarker(record MigrationRecord) {
+	data, err := json.Marshal(record)
+	if err != nil {
+		log.Warnf("config migration: failed to encode marker: %v", err)
+		return
+	}
+	// The data directory may not exist yet when only the config directory
+	// moved.
+	if err := os.MkdirAll(getDataDir(), 0o700); err != nil {
+		log.Warnf("config migration: failed to create data directory for marker: %v", err)
+		return
+	}
+	if err := os.WriteFile(migrationMarkerPath(), data, 0o600); err != nil {
+		log.Warnf("config migration: failed to write marker: %v", err)
+	}
+}
+
+// ConsumeMigrationMarker returns the pending migration record and removes
+// the marker file. It returns nil when no migration is pending. The CLI
+// calls it after the store opens to write the self-audit entry, because this
+// package must not depend on storage.
+func ConsumeMigrationMarker() *MigrationRecord {
+	path := migrationMarkerPath()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warnf("config migration: failed to read marker: %v", err)
+		}
+		return nil
+	}
+
+	if err := os.Remove(path); err != nil {
+		log.Warnf("config migration: failed to remove marker: %v", err)
+	}
+
+	record := &MigrationRecord{}
+	if err := json.Unmarshal(data, record); err != nil {
+		log.Warnf("config migration: failed to decode marker: %v", err)
+		return nil
+	}
+
+	return record
+}

--- a/config/migrate_test.go
+++ b/config/migrate_test.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupMigrationEnv isolates HOME and every XDG base in temp directories and
+// returns the config and data bases.
+func setupMigrationEnv(t *testing.T) (string, string) {
+	t.Helper()
+	clearPathEnv(t)
+
+	configBase := t.TempDir()
+	dataBase := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", configBase)
+	t.Setenv("XDG_DATA_HOME", dataBase)
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	return configBase, dataBase
+}
+
+func seedLegacyConfigTree(t *testing.T, configBase string) string {
+	t.Helper()
+
+	legacy := filepath.Join(configBase, legacyLeaf)
+	require.NoError(t, os.MkdirAll(filepath.Join(legacy, "keys"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, legacyConfigFileName),
+		[]byte("logging:\n  level: full\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "policy.yaml"),
+		[]byte("version: 1\n"), 0o600))
+
+	return legacy
+}
+
+func TestMigrateLegacyLayout_MovesLegacyTree(t *testing.T) {
+	configBase, dataBase := setupMigrationEnv(t)
+
+	legacyConfig := seedLegacyConfigTree(t, configBase)
+	legacyData := filepath.Join(dataBase, legacyLeaf)
+	require.NoError(t, os.MkdirAll(legacyData, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyData, "audit.db"), []byte("db"), 0o600))
+	legacyCache := legacyCacheDir()
+	require.NoError(t, os.MkdirAll(legacyCache, 0o700))
+
+	migrateLegacyLayout()
+
+	newConfig := filepath.Join(configBase, "safedep", "gryph")
+	newData := filepath.Join(dataBase, "safedep", "gryph")
+	assert.NoDirExists(t, legacyConfig)
+	assert.NoDirExists(t, legacyData)
+	assert.NoDirExists(t, legacyCache)
+	assert.FileExists(t, filepath.Join(newConfig, configFileName))
+	assert.NoFileExists(t, filepath.Join(newConfig, legacyConfigFileName))
+	assert.FileExists(t, filepath.Join(newConfig, "policy.yaml"))
+	assert.DirExists(t, filepath.Join(newConfig, "keys"))
+	assert.FileExists(t, filepath.Join(newData, "audit.db"))
+
+	record := ConsumeMigrationMarker()
+	require.NotNil(t, record)
+	assert.Len(t, record.Moves, 2)
+	assert.Empty(t, record.Warnings)
+	assert.Nil(t, ConsumeMigrationMarker(), "the marker is consumed once")
+
+	migrateLegacyLayout()
+	assert.Nil(t, ConsumeMigrationMarker(), "a second run is a no-op")
+}
+
+func TestMigrateLegacyLayout_SamePairMovesOnce(t *testing.T) {
+	clearPathEnv(t)
+	base := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv("XDG_DATA_HOME", base)
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	seedLegacyConfigTree(t, base)
+
+	migrateLegacyLayout()
+
+	assert.FileExists(t, filepath.Join(base, "safedep", "gryph", configFileName))
+
+	record := ConsumeMigrationMarker()
+	require.NotNil(t, record)
+	assert.Len(t, record.Moves, 1, "config and data resolve to one pair and move once")
+}
+
+func TestMigrateLegacyLayout_BothExistKeepsNew(t *testing.T) {
+	configBase, _ := setupMigrationEnv(t)
+
+	legacy := seedLegacyConfigTree(t, configBase)
+	newConfig := filepath.Join(configBase, "safedep", "gryph")
+	require.NoError(t, os.MkdirAll(newConfig, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(newConfig, configFileName),
+		[]byte("logging:\n  level: minimal\n"), 0o600))
+
+	migrateLegacyLayout()
+
+	assert.DirExists(t, legacy, "the legacy directory is left for manual reconciliation")
+	data, err := os.ReadFile(filepath.Join(newConfig, configFileName))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "minimal", "the new directory wins")
+	assert.Nil(t, ConsumeMigrationMarker(), "no move means no marker")
+}
+
+func TestMigrateLegacyLayout_EnvOverrideSkipsMoveButNormalizesName(t *testing.T) {
+	configBase, _ := setupMigrationEnv(t)
+	legacy := seedLegacyConfigTree(t, configBase)
+
+	override := t.TempDir()
+	t.Setenv(configDirEnvKey, override)
+	require.NoError(t, os.WriteFile(filepath.Join(override, legacyConfigFileName),
+		[]byte("logging:\n  level: full\n"), 0o600))
+
+	migrateLegacyLayout()
+
+	assert.DirExists(t, legacy, "an override skips the move for that kind")
+	assert.FileExists(t, filepath.Join(override, configFileName))
+	assert.NoFileExists(t, filepath.Join(override, legacyConfigFileName))
+}
+
+func TestMigrateLegacyLayout_SudoElevationSkips(t *testing.T) {
+	configBase, _ := setupMigrationEnv(t)
+	legacy := seedLegacyConfigTree(t, configBase)
+
+	restoreGeteuid := configGeteuid
+	configGeteuid = func() int { return 0 }
+	t.Cleanup(func() { configGeteuid = restoreGeteuid })
+	t.Setenv("SUDO_USER", "someone")
+
+	migrateLegacyLayout()
+
+	assert.DirExists(t, legacy, "an elevated run never moves the invoking user's files")
+	assert.NoDirExists(t, filepath.Join(configBase, "safedep", "gryph"))
+}
+
+func TestNormalizeConfigFileName_KeepsBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, legacyConfigFileName), []byte("a: 1\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, configFileName), []byte("b: 2\n"), 0o600))
+
+	normalizeConfigFileName(dir)
+
+	assert.FileExists(t, filepath.Join(dir, legacyConfigFileName))
+	data, err := os.ReadFile(filepath.Join(dir, configFileName))
+	require.NoError(t, err)
+	assert.Equal(t, "b: 2\n", string(data))
+}
+
+func TestLegacyResolvers_PreferPreexistingXDGDirs(t *testing.T) {
+	clearPathEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+
+	legacyConfig := filepath.Join(home, ".config", legacyLeaf)
+	require.NoError(t, os.MkdirAll(legacyConfig, 0o700))
+	legacyData := filepath.Join(home, ".local", "share", legacyLeaf)
+	require.NoError(t, os.MkdirAll(legacyData, 0o700))
+
+	assert.Equal(t, legacyConfig, legacyConfigDir())
+	assert.Equal(t, legacyData, legacyDataDir())
+}

--- a/config/paths.go
+++ b/config/paths.go
@@ -1,108 +1,178 @@
 package config
 
 import (
+	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
+
+	"github.com/safedep/dry/log"
 )
 
-// getConfigDir returns the configuration directory for gryph.
-//
-// Resolution order:
-//  1. $XDG_CONFIG_HOME/gryph if the environment variable is set (all platforms).
-//     Go's os.UserConfigDir honors this on Linux but not on macOS or Windows;
-//     we extend it to all platforms so users who organize their configs under
-//     an XDG-style layout get a consistent location across systems.
-//  2. $HOME/.config/gryph if that directory already exists (all platforms).
-//     This lets users who have opted into the XDG layout on macOS/Windows
-//     keep their configs in one place without setting an environment variable.
-//  3. Platform default via os.UserConfigDir (Linux $XDG_CONFIG_HOME or
-//     $HOME/.config, macOS $HOME/Library/Application Support, Windows %AppData%).
-func getConfigDir() string {
-	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
-		return filepath.Join(xdgConfig, "gryph")
+// defaultHomeRelativePath is the SafeDep shared namespace leaf appended to
+// every base directory.
+const defaultHomeRelativePath = "safedep/gryph"
+
+// Directory overrides. Each value names the final directory, with no leaf
+// appended.
+const (
+	configDirEnvKey = "GRYPH_CONFIG_DIR"
+	dataDirEnvKey   = "GRYPH_DATA_DIR"
+	cacheDirEnvKey  = "GRYPH_CACHE_DIR"
+)
+
+// resolveDir applies the shared resolution order for one directory kind:
+// the GRYPH_* override, then the sudo guard, then the XDG base, then the
+// platform base. XDG variables are honored on every platform, not only
+// where os.UserConfigDir does, so users with an XDG layout on macOS or
+// Windows keep one location across systems. A relative XDG value is
+// ignored, as the XDG spec requires.
+func resolveDir(overrideEnvKey, xdgEnvKey string, rootBase func() (string, error), platformBase func() string) string {
+	if dir := os.Getenv(overrideEnvKey); dir != "" {
+		return dir
 	}
-	if home, err := os.UserHomeDir(); err == nil {
-		xdgDefault := filepath.Join(home, ".config", "gryph")
-		if info, err := os.Stat(xdgDefault); err == nil && info.IsDir() {
-			return xdgDefault
+	if isSudoElevation() {
+		if base, err := rootBase(); err == nil {
+			return filepath.Join(base, defaultHomeRelativePath)
+		} else {
+			// No resolvable root passwd entry, e.g. scratch containers.
+			// Without a passwd database there is no user switching, so the
+			// cross-user poisoning the guard prevents cannot occur.
+			log.Warnf("failed to resolve root home, using environment: %v", err)
 		}
 	}
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		// Fallback to home directory
-		home, _ := os.UserHomeDir()
-		configDir = filepath.Join(home, ".config")
+	if base := os.Getenv(xdgEnvKey); filepath.IsAbs(base) {
+		return filepath.Join(base, defaultHomeRelativePath)
 	}
-	return filepath.Join(configDir, "gryph")
+	return filepath.Join(platformBase(), defaultHomeRelativePath)
+}
+
+// getConfigDir returns the configuration directory for gryph.
+func getConfigDir() string {
+	return resolveDir(configDirEnvKey, "XDG_CONFIG_HOME", rootConfigDirResolver, configBaseDir)
 }
 
 // getDataDir returns the data directory for gryph.
-//
-// Resolution order:
-//  1. $XDG_DATA_HOME/gryph if the environment variable is set (all platforms).
-//     Mirrors the config-dir behaviour above — respect the XDG base dir spec
-//     everywhere, not just on Linux, for users who want a single layout.
-//  2. $HOME/.local/share/gryph if that directory already exists (all
-//     platforms), for users who have opted into the XDG layout on
-//     macOS/Windows without setting environment variables.
-//  3. Platform default: Linux $HOME/.local/share, macOS $HOME/Library/
-//     Application Support, Windows %LocalAppData%.
 func getDataDir() string {
-	if xdgData := os.Getenv("XDG_DATA_HOME"); xdgData != "" {
-		return filepath.Join(xdgData, "gryph")
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		xdgDefault := filepath.Join(home, ".local", "share", "gryph")
-		if info, err := os.Stat(xdgDefault); err == nil && info.IsDir() {
-			return xdgDefault
-		}
-	}
-
-	switch runtime.GOOS {
-	case "linux":
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, ".local", "share", "gryph")
-
-	case "darwin":
-		// macOS: Use Application Support (same as config)
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, "Library", "Application Support", "gryph")
-
-	case "windows":
-		// Windows: Use LocalAppData
-		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
-			return filepath.Join(localAppData, "gryph")
-		}
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, "AppData", "Local", "gryph")
-
-	default:
-		// Fallback: use config directory
-		return getConfigDir()
-	}
+	return resolveDir(dataDirEnvKey, "XDG_DATA_HOME", rootDataDirResolver, dataBaseDir)
 }
 
 // getCacheDir returns the cache directory for gryph.
 func getCacheDir() string {
-	cacheDir, err := os.UserCacheDir()
+	return resolveDir(cacheDirEnvKey, "XDG_CACHE_HOME", rootCacheDirResolver, cacheBaseDir)
+}
+
+func configBaseDir() string {
+	dir, err := os.UserConfigDir()
 	if err != nil {
-		// Fallback to home directory
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".config")
+	}
+	return dir
+}
+
+func dataBaseDir() string {
+	switch runtime.GOOS {
+	case "darwin":
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, "Library", "Application Support")
+	case "windows":
+		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+			return localAppData
+		}
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, "AppData", "Local")
+	default:
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".local", "share")
+	}
+}
+
+func cacheBaseDir() string {
+	dir, err := os.UserCacheDir()
+	if err != nil {
 		home, _ := os.UserHomeDir()
 		switch runtime.GOOS {
 		case "darwin":
-			cacheDir = filepath.Join(home, "Library", "Caches")
+			return filepath.Join(home, "Library", "Caches")
 		case "windows":
-			cacheDir = filepath.Join(home, "AppData", "Local")
+			return filepath.Join(home, "AppData", "Local")
 		default:
-			cacheDir = filepath.Join(home, ".cache")
+			return filepath.Join(home, ".cache")
 		}
 	}
-	return filepath.Join(cacheDir, "gryph")
+	return dir
 }
+
+// configGeteuid is overridable in tests. os.Geteuid returns -1 on Windows,
+// which disables the guard there.
+var configGeteuid = os.Geteuid
+
+// isSudoElevation reports a root run started through sudo. Only then do the
+// resolvers divert to root's passwd home: sudo can preserve the invoking
+// user's HOME and XDG_*, and a root run must not create root owned state in
+// that user's home. A genuine root login keeps honoring its environment.
+func isSudoElevation() bool {
+	return configGeteuid() == 0 && os.Getenv("SUDO_USER") != ""
+}
+
+func rootHomeDir() (string, error) {
+	u, err := user.LookupId("0")
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve root home directory: %w", err)
+	}
+	if u.HomeDir == "" {
+		return "", fmt.Errorf("root user has no home directory")
+	}
+	return u.HomeDir, nil
+}
+
+func rootConfigDir() (string, error) {
+	home, err := rootHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Application Support"), nil
+	}
+	return filepath.Join(home, ".config"), nil
+}
+
+func rootDataDir() (string, error) {
+	home, err := rootHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Application Support"), nil
+	}
+	return filepath.Join(home, ".local", "share"), nil
+}
+
+func rootCacheDir() (string, error) {
+	home, err := rootHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Caches"), nil
+	}
+	return filepath.Join(home, ".cache"), nil
+}
+
+// Overridable in tests to exercise root path resolution and the
+// passwd-unavailable fallback.
+var (
+	rootConfigDirResolver = rootConfigDir
+	rootDataDirResolver   = rootDataDir
+	rootCacheDirResolver  = rootCacheDir
+)
 
 // EnsureDirectories creates all required directories if they don't exist.
 func EnsureDirectories() error {
+	MigrateLegacyLayout()
+
 	paths := ResolvePaths()
 
 	dirs := []string{

--- a/config/paths_test.go
+++ b/config/paths_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// clearPathEnv neutralizes the environment that steers path resolution, so a
+// test controls only the variables it sets.
+func clearPathEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(configDirEnvKey, "")
+	t.Setenv(dataDirEnvKey, "")
+	t.Setenv(cacheDirEnvKey, "")
+	t.Setenv("SUDO_USER", "")
+}
+
+func TestResolveDir_EnvOverrideWins(t *testing.T) {
+	tests := []struct {
+		name    string
+		envKey  string
+		resolve func() string
+	}{
+		{"config", configDirEnvKey, getConfigDir},
+		{"data", dataDirEnvKey, getDataDir},
+		{"cache", cacheDirEnvKey, getCacheDir},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearPathEnv(t)
+			dir := t.TempDir()
+			t.Setenv(tc.envKey, dir)
+
+			assert.Equal(t, dir, tc.resolve())
+		})
+	}
+}
+
+func TestResolveDir_XDGHonoredOnAllPlatforms(t *testing.T) {
+	tests := []struct {
+		name    string
+		xdgKey  string
+		resolve func() string
+	}{
+		{"config", "XDG_CONFIG_HOME", getConfigDir},
+		{"data", "XDG_DATA_HOME", getDataDir},
+		{"cache", "XDG_CACHE_HOME", getCacheDir},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clearPathEnv(t)
+			base := t.TempDir()
+			t.Setenv(tc.xdgKey, base)
+
+			assert.Equal(t, filepath.Join(base, "safedep", "gryph"), tc.resolve())
+		})
+	}
+}
+
+func TestResolveDir_RelativeXDGIgnored(t *testing.T) {
+	clearPathEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "relative/path")
+
+	got := getConfigDir()
+	assert.True(t, filepath.IsAbs(got))
+	assert.NotContains(t, got, "relative/path")
+	assert.True(t, strings.HasSuffix(got, filepath.Join("safedep", "gryph")))
+}
+
+func withSudoElevation(t *testing.T, rootConfigBase string, rootErr error) {
+	t.Helper()
+
+	restoreGeteuid := configGeteuid
+	restoreResolver := rootConfigDirResolver
+	configGeteuid = func() int { return 0 }
+	rootConfigDirResolver = func() (string, error) {
+		if rootErr != nil {
+			return "", rootErr
+		}
+		return rootConfigBase, nil
+	}
+	t.Cleanup(func() {
+		configGeteuid = restoreGeteuid
+		rootConfigDirResolver = restoreResolver
+	})
+
+	t.Setenv("SUDO_USER", "someone")
+}
+
+func TestResolveDir_SudoGuardUsesRootHome(t *testing.T) {
+	clearPathEnv(t)
+	rootBase := t.TempDir()
+	withSudoElevation(t, rootBase, nil)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	assert.Equal(t, filepath.Join(rootBase, "safedep", "gryph"), getConfigDir())
+}
+
+func TestResolveDir_SudoGuardFallsBackWithoutPasswd(t *testing.T) {
+	clearPathEnv(t)
+	withSudoElevation(t, "", errors.New("no passwd database"))
+	xdgBase := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgBase)
+
+	assert.Equal(t, filepath.Join(xdgBase, "safedep", "gryph"), getConfigDir())
+}
+
+func TestResolveDir_NoSudoGuardWithoutSudoUser(t *testing.T) {
+	clearPathEnv(t)
+	rootBase := t.TempDir()
+	withSudoElevation(t, rootBase, nil)
+	t.Setenv("SUDO_USER", "")
+	xdgBase := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdgBase)
+
+	assert.Equal(t, filepath.Join(xdgBase, "safedep", "gryph"), getConfigDir())
+}

--- a/config/system.go
+++ b/config/system.go
@@ -28,15 +28,15 @@ func systemConfigDir() string {
 
 	switch runtime.GOOS {
 	case "darwin":
-		return "/Library/Application Support/safedep/gryph"
+		return filepath.Join("/Library/Application Support", defaultHomeRelativePath)
 	case "linux":
-		return "/etc/safedep/gryph"
+		return filepath.Join("/etc", defaultHomeRelativePath)
 	case "windows":
 		programData := os.Getenv("PROGRAMDATA")
 		if programData == "" {
 			programData = `C:\ProgramData`
 		}
-		return filepath.Join(programData, "safedep", "gryph")
+		return filepath.Join(programData, defaultHomeRelativePath)
 	}
 
 	return ""

--- a/config/system.go
+++ b/config/system.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/safedep/dry/log"
+)
+
+// configFileName is the canonical config file name across SafeDep tools.
+const configFileName = "config.yml"
+
+// globalConfigDirOverride replaces the system managed config directory in
+// tests. There is no env var or flag on purpose: a user must not be able to
+// point the managed path at a file they own and bypass governance.
+var globalConfigDirOverride string
+
+// systemConfigDir returns the root owned directory for system managed gryph
+// state, or "" when the platform has no such location. Today only
+// config.yml is read from it. The directory mirrors the per-user config
+// directory layout, so policy.yaml, policies/ and keys/receipt-pub.json are
+// reserved for a future managed policy and trust store.
+func systemConfigDir() string {
+	if globalConfigDirOverride != "" {
+		return globalConfigDirOverride
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return "/Library/Application Support/safedep/gryph"
+	case "linux":
+		return "/etc/safedep/gryph"
+	case "windows":
+		programData := os.Getenv("PROGRAMDATA")
+		if programData == "" {
+			programData = `C:\ProgramData`
+		}
+		return filepath.Join(programData, "safedep", "gryph")
+	}
+
+	return ""
+}
+
+// managedFileTrusted is overridable in tests, which cannot create root owned
+// files.
+var managedFileTrusted = verifyManagedFileTrust
+
+// ManagedConfigFile returns the system managed config file when it exists,
+// is a regular file, and passes the trust check. It returns "" otherwise.
+// While a managed file is active, it is authoritative and the per-user
+// config file is ignored.
+func ManagedConfigFile() string {
+	dir := systemConfigDir()
+	if dir == "" {
+		return ""
+	}
+
+	path := filepath.Join(dir, configFileName)
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return ""
+	}
+
+	if !managedFileTrusted(info) {
+		log.Warnf("ignoring managed config %s: the file is not root owned or is writable by group or other", path)
+		return ""
+	}
+
+	return path
+}

--- a/config/system_test.go
+++ b/config/system_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withManagedConfigDir points the managed config location at dir and makes
+// the trust check pass, because tests cannot create root owned files.
+func withManagedConfigDir(t *testing.T, dir string) {
+	t.Helper()
+
+	restoreDir := globalConfigDirOverride
+	restoreTrust := managedFileTrusted
+	globalConfigDirOverride = dir
+	managedFileTrusted = func(os.FileInfo) bool { return true }
+	t.Cleanup(func() {
+		globalConfigDirOverride = restoreDir
+		managedFileTrusted = restoreTrust
+	})
+}
+
+func TestManagedConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	withManagedConfigDir(t, dir)
+
+	assert.Empty(t, ManagedConfigFile())
+
+	path := filepath.Join(dir, configFileName)
+	require.NoError(t, os.WriteFile(path, []byte("logging:\n  level: full\n"), 0o644))
+	assert.Equal(t, path, ManagedConfigFile())
+}
+
+func TestManagedConfigFile_UntrustedFileIgnored(t *testing.T) {
+	dir := t.TempDir()
+	withManagedConfigDir(t, dir)
+	managedFileTrusted = func(os.FileInfo) bool { return false }
+
+	path := filepath.Join(dir, configFileName)
+	require.NoError(t, os.WriteFile(path, []byte("logging:\n  level: full\n"), 0o644))
+
+	assert.Empty(t, ManagedConfigFile())
+}
+
+func TestLoad_ManagedConfigWinsOverUserConfig(t *testing.T) {
+	clearPathEnv(t)
+
+	userBase := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", userBase)
+	userDir := filepath.Join(userBase, "safedep", "gryph")
+	require.NoError(t, os.MkdirAll(userDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(userDir, configFileName),
+		[]byte("logging:\n  level: minimal\n"), 0o600))
+
+	managedDir := t.TempDir()
+	withManagedConfigDir(t, managedDir)
+	require.NoError(t, os.WriteFile(filepath.Join(managedDir, configFileName),
+		[]byte("logging:\n  level: full\n"), 0o644))
+
+	cfg, err := Load("")
+	require.NoError(t, err)
+	assert.Equal(t, LoggingFull, cfg.Logging.Level)
+
+	explicit := filepath.Join(t.TempDir(), "explicit.yml")
+	require.NoError(t, os.WriteFile(explicit, []byte("logging:\n  level: standard\n"), 0o600))
+
+	cfg, err = Load(explicit)
+	require.NoError(t, err)
+	assert.Equal(t, LoggingStandard, cfg.Logging.Level)
+}
+
+func TestLoad_UserConfigWithoutManagedFile(t *testing.T) {
+	clearPathEnv(t)
+
+	userBase := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", userBase)
+	userDir := filepath.Join(userBase, "safedep", "gryph")
+	require.NoError(t, os.MkdirAll(userDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(userDir, configFileName),
+		[]byte("logging:\n  level: minimal\n"), 0o600))
+
+	withManagedConfigDir(t, t.TempDir())
+
+	cfg, err := Load("")
+	require.NoError(t, err)
+	assert.Equal(t, LoggingMinimal, cfg.Logging.Level)
+}
+
+func TestLoad_GryphDirEnvDoesNotBindConfigValues(t *testing.T) {
+	clearPathEnv(t)
+	t.Setenv(configDirEnvKey, t.TempDir())
+	t.Setenv(dataDirEnvKey, t.TempDir())
+	t.Setenv(cacheDirEnvKey, t.TempDir())
+
+	cfg, err := Load("")
+	require.NoError(t, err)
+	assert.Equal(t, Default(), cfg)
+}
+
+func TestVerifyManagedFileTrust(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the Windows build accepts every file until an ACL check lands")
+	}
+
+	path := filepath.Join(t.TempDir(), configFileName)
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	if os.Geteuid() == 0 {
+		assert.True(t, verifyManagedFileTrust(info))
+	} else {
+		assert.False(t, verifyManagedFileTrust(info))
+	}
+
+	require.NoError(t, os.Chmod(path, 0o664))
+	info, err = os.Stat(path)
+	require.NoError(t, err)
+	assert.False(t, verifyManagedFileTrust(info), "a group writable file is never trusted")
+}

--- a/config/system_test.go
+++ b/config/system_test.go
@@ -47,7 +47,7 @@ func TestManagedConfigFile_UntrustedFileIgnored(t *testing.T) {
 	assert.Empty(t, ManagedConfigFile())
 }
 
-func TestLoad_ManagedConfigWinsOverUserConfig(t *testing.T) {
+func TestLoad_ManagedConfigIsAuthoritative(t *testing.T) {
 	clearPathEnv(t)
 
 	userBase := t.TempDir()
@@ -64,12 +64,25 @@ func TestLoad_ManagedConfigWinsOverUserConfig(t *testing.T) {
 
 	cfg, err := Load("")
 	require.NoError(t, err)
-	assert.Equal(t, LoggingFull, cfg.Logging.Level)
+	assert.Equal(t, LoggingFull, cfg.Logging.Level, "the managed file wins over the per-user file")
 
 	explicit := filepath.Join(t.TempDir(), "explicit.yml")
 	require.NoError(t, os.WriteFile(explicit, []byte("logging:\n  level: standard\n"), 0o600))
 
 	cfg, err = Load(explicit)
+	require.NoError(t, err)
+	assert.Equal(t, LoggingFull, cfg.Logging.Level, "the managed file wins over an explicit --config path")
+}
+
+func TestLoad_ExplicitPathWinsWithoutManagedFile(t *testing.T) {
+	clearPathEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	withManagedConfigDir(t, t.TempDir())
+
+	explicit := filepath.Join(t.TempDir(), "explicit.yml")
+	require.NoError(t, os.WriteFile(explicit, []byte("logging:\n  level: standard\n"), 0o600))
+
+	cfg, err := Load(explicit)
 	require.NoError(t, err)
 	assert.Equal(t, LoggingStandard, cfg.Logging.Level)
 }

--- a/config/system_unix.go
+++ b/config/system_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"syscall"
+)
+
+// verifyManagedFileTrust accepts only a root owned file that group and other
+// cannot write. Anything else would let a user plant a fake managed config
+// that governs every user on the machine.
+func verifyManagedFileTrust(info os.FileInfo) bool {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return st.Uid == 0 && info.Mode().Perm()&0o022 == 0
+}

--- a/config/system_windows.go
+++ b/config/system_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package config
+
+import "os"
+
+// Windows has no owner check without ACL inspection, so the file is
+// accepted. This matches PMG. An ACL check must land before the managed
+// directory carries policy, because standard users can create directories
+// under %PROGRAMDATA%.
+func verifyManagedFileTrust(_ os.FileInfo) bool {
+	return true
+}

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -30,7 +30,7 @@ Once enabled, every supported agent hook runs through the engine.
 
 Gryph loads policy from three sources, in this order:
 
-1. **Global policy file** (`${ConfigDir}/policy.yaml`, optional). The single operator-owned file. On macOS this is `~/Library/Application Support/gryph/policy.yaml`; on Linux `~/.config/gryph/policy.yaml`. A missing file is not an error.
+1. **Global policy file** (`${ConfigDir}/policy.yaml`, optional). The single operator-owned file. On macOS this is `~/Library/Application Support/safedep/gryph/policy.yaml`; on Linux `~/.config/safedep/gryph/policy.yaml`. A missing file is not an error.
 2. **Policies directory** (`${ConfigDir}/policies/*.yaml` and `*.yml`, optional). Each file is a separate policy document. Files load in sorted name order and merge after the global file. A missing directory is not an error. This lets you author policy as many small, self-contained files instead of one large file.
 3. **Built-in self-protection rules** (always appended, never filtered). These protect the config directory, the database, and agent hook configs from agent self-modification.
 
@@ -548,7 +548,7 @@ Read this before relying on receipt signatures as evidence outside your own host
 
 - **Tamper detection on exported receipts.** A third party with the pubkey can verify a JSONL export came from your host and was not modified in transit.
 - **Per-host attribution.** Aggregating receipts from many hosts at one SIEM, each host's signature ties its rows back to that host's key.
-- **In-DB tamper by something that does not have key access.** Rare on a single-user host since the key sits in `~/.config/gryph/keys/` at the operator's UID.
+- **In-DB tamper by something that does not have key access.** Rare on a single-user host since the key sits in `~/.config/safedep/gryph/keys/` at the operator's UID.
 
 ### What signing does not protect
 

--- a/docs/streams-dev.md
+++ b/docs/streams-dev.md
@@ -14,7 +14,7 @@ This prints all unsynced events and audit entries as JSON to stdout.
 
 ## Configuration
 
-Targets live under `streams.targets` in `~/.config/gryph/config.yaml` (Linux) or `~/Library/Application Support/gryph/config.yaml` (macOS):
+Targets live under `streams.targets` in `~/.config/safedep/gryph/config.yml` (Linux) or `~/Library/Application Support/safedep/gryph/config.yml` (macOS):
 
 ```yaml
 streams:

--- a/storage/ent/migrate/schema.go
+++ b/storage/ent/migrate/schema.go
@@ -295,7 +295,7 @@ var (
 	SelfAuditsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID},
 		{Name: "timestamp", Type: field.TypeTime},
-		{Name: "action", Type: field.TypeEnum, Enums: []string{"install", "uninstall", "config_change", "export", "purge", "upgrade", "database_init", "retention_cleanup", "hook_error", "policy_load_error", "context_cleanup", "context_snapshot_error", "context_chain_broken", "receipt_cleanup", "receipt_insert_error", "receipt_chain_broken", "receipt_signed", "receipt_signature_invalid", "receipt_key_rotated", "approval_requested", "approval_granted", "approval_denied", "approval_timeout", "deferral_requested", "deferral_resolved", "deferral_timeout", "deferral_sweep", "deferral_cleanup", "identity_missing"}},
+		{Name: "action", Type: field.TypeEnum, Enums: []string{"install", "uninstall", "config_change", "export", "purge", "upgrade", "database_init", "retention_cleanup", "hook_error", "policy_load_error", "context_cleanup", "context_snapshot_error", "context_chain_broken", "receipt_cleanup", "receipt_insert_error", "receipt_chain_broken", "receipt_signed", "receipt_signature_invalid", "receipt_key_rotated", "approval_requested", "approval_granted", "approval_denied", "approval_timeout", "deferral_requested", "deferral_resolved", "deferral_timeout", "deferral_sweep", "deferral_cleanup", "identity_missing", "path_migration"}},
 		{Name: "agent_name", Type: field.TypeString, Nullable: true},
 		{Name: "details", Type: field.TypeJSON, Nullable: true},
 		{Name: "result", Type: field.TypeEnum, Enums: []string{"success", "error", "skipped"}, Default: "success"},

--- a/storage/ent/schema/selfaudit.go
+++ b/storage/ent/schema/selfaudit.go
@@ -26,7 +26,7 @@ func (SelfAudit) Fields() []ent.Field {
 		// Keep these values in sync with the SelfAuditAction* constants in
 		// cli/audit.go. Ent validates writes against this enum at runtime.
 		field.Enum("action").
-			Values("install", "uninstall", "config_change", "export", "purge", "upgrade", "database_init", "retention_cleanup", "hook_error", "policy_load_error", "context_cleanup", "context_snapshot_error", "context_chain_broken", "receipt_cleanup", "receipt_insert_error", "receipt_chain_broken", "receipt_signed", "receipt_signature_invalid", "receipt_key_rotated", "approval_requested", "approval_granted", "approval_denied", "approval_timeout", "deferral_requested", "deferral_resolved", "deferral_timeout", "deferral_sweep", "deferral_cleanup", "identity_missing"),
+			Values("install", "uninstall", "config_change", "export", "purge", "upgrade", "database_init", "retention_cleanup", "hook_error", "policy_load_error", "context_cleanup", "context_snapshot_error", "context_chain_broken", "receipt_cleanup", "receipt_insert_error", "receipt_chain_broken", "receipt_signed", "receipt_signature_invalid", "receipt_key_rotated", "approval_requested", "approval_granted", "approval_denied", "approval_timeout", "deferral_requested", "deferral_resolved", "deferral_timeout", "deferral_sweep", "deferral_cleanup", "identity_missing", "path_migration"),
 		field.String("agent_name").
 			Optional(),
 		field.JSON("details", map[string]interface{}{}).

--- a/storage/ent/selfaudit/selfaudit.go
+++ b/storage/ent/selfaudit/selfaudit.go
@@ -98,6 +98,7 @@ const (
 	ActionDeferralSweep           Action = "deferral_sweep"
 	ActionDeferralCleanup         Action = "deferral_cleanup"
 	ActionIdentityMissing         Action = "identity_missing"
+	ActionPathMigration           Action = "path_migration"
 )
 
 func (a Action) String() string {
@@ -107,7 +108,7 @@ func (a Action) String() string {
 // ActionValidator is a validator for the "action" field enum values. It is called by the builders before save.
 func ActionValidator(a Action) error {
 	switch a {
-	case ActionInstall, ActionUninstall, ActionConfigChange, ActionExport, ActionPurge, ActionUpgrade, ActionDatabaseInit, ActionRetentionCleanup, ActionHookError, ActionPolicyLoadError, ActionContextCleanup, ActionContextSnapshotError, ActionContextChainBroken, ActionReceiptCleanup, ActionReceiptInsertError, ActionReceiptChainBroken, ActionReceiptSigned, ActionReceiptSignatureInvalid, ActionReceiptKeyRotated, ActionApprovalRequested, ActionApprovalGranted, ActionApprovalDenied, ActionApprovalTimeout, ActionDeferralRequested, ActionDeferralResolved, ActionDeferralTimeout, ActionDeferralSweep, ActionDeferralCleanup, ActionIdentityMissing:
+	case ActionInstall, ActionUninstall, ActionConfigChange, ActionExport, ActionPurge, ActionUpgrade, ActionDatabaseInit, ActionRetentionCleanup, ActionHookError, ActionPolicyLoadError, ActionContextCleanup, ActionContextSnapshotError, ActionContextChainBroken, ActionReceiptCleanup, ActionReceiptInsertError, ActionReceiptChainBroken, ActionReceiptSigned, ActionReceiptSignatureInvalid, ActionReceiptKeyRotated, ActionApprovalRequested, ActionApprovalGranted, ActionApprovalDenied, ActionApprovalTimeout, ActionDeferralRequested, ActionDeferralResolved, ActionDeferralTimeout, ActionDeferralSweep, ActionDeferralCleanup, ActionIdentityMissing, ActionPathMigration:
 		return nil
 	default:
 		return fmt.Errorf("selfaudit: invalid enum value for action field: %q", a)

--- a/test/acceptance/catalog.yaml
+++ b/test/acceptance/catalog.yaml
@@ -258,6 +258,27 @@
   guarantee: "A command is blocked after the session reads a secret-classified path, and a tool call with prompt injection markers is blocked while a benign one passes."
   labels: [policy, classify, injection]
 
+- id: migration/layout/legacy-tree-moves
+  title: "a pre safedep/gryph install moves to the new layout on first run"
+  category: migration
+  tier: P0
+  guarantee: "The first run moves the legacy gryph config and data directories to the safedep/gryph layout, renames config.yaml to config.yml, keeps the stored state intact, and records a path_migration self-audit entry."
+  labels: [migration, config, storage]
+
+- id: migration/layout/env-override-normalizes
+  title: "GRYPH_CONFIG_DIR is used as-is and its config name is normalized"
+  category: migration
+  tier: P1
+  guarantee: "GRYPH_CONFIG_DIR names the final config directory with no leaf appended. The directory is not moved, and a config.yaml inside it is renamed to config.yml."
+  labels: [migration, config, env]
+
+- id: migration/layout/both-exist-new-wins
+  title: "when legacy and new directories both exist, the new one wins"
+  category: migration
+  tier: P1
+  guarantee: "When the legacy and the new config directory both exist, gryph reads the new directory, merges nothing, and leaves the legacy directory in place."
+  labels: [migration, config]
+
 # --- gaps: tracked guarantees with no script yet ---
 
 - id: retention/cleanup/old-events-deleted

--- a/test/acceptance/scripts/config/env/override-wins.txtar
+++ b/test/acceptance/scripts/config/env/override-wins.txtar
@@ -25,7 +25,7 @@ env GRYPH_STORAGE_RETENTION_DAYS=7
 exec gryph retention status --no-color
 stdout 'Events Retention Days:\s+7'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 logging:
   level: full
 storage:

--- a/test/acceptance/scripts/errors/exit-codes/contract.txtar
+++ b/test/acceptance/scripts/errors/exit-codes/contract.txtar
@@ -13,12 +13,12 @@ execexit 2 gryph policy receipts verify-log
 stderr 'input is required'
 
 # 3: the database cannot open. A directory at the database path forces it.
-rm $XDG_DATA_HOME/gryph/audit.db
-mkdir $XDG_DATA_HOME/gryph/audit.db
+rm $XDG_DATA_HOME/safedep/gryph/audit.db
+mkdir $XDG_DATA_HOME/safedep/gryph/audit.db
 execexit 3 gryph logs
 stderr 'failed to open database'
 
 # 0: a healthy command.
-rm $XDG_DATA_HOME/gryph/audit.db
+rm $XDG_DATA_HOME/safedep/gryph/audit.db
 exec gryph version
 stdout 'gryph'

--- a/test/acceptance/scripts/events/diff/unified-by-id.txtar
+++ b/test/acceptance/scripts/events/diff/unified-by-id.txtar
@@ -22,7 +22,7 @@ stdout 'file_write'
 stdout 'a.txt'
 stdout 'Status\s+success'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 logging:
   level: full
 -- home/project/a.txt --

--- a/test/acceptance/scripts/hook/protocols/block-matrix.txtar
+++ b/test/acceptance/scripts/hook/protocols/block-matrix.txtar
@@ -29,12 +29,12 @@ stdout '"permissionDecision":"deny"'
 exec gryph query --status blocked --format json --no-color
 stdout -count=5 '"ResultStatus": "blocked"'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
   log_all_evaluations: true
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-block-npm-install

--- a/test/acceptance/scripts/hook/robustness/concurrent-writes.txtar
+++ b/test/acceptance/scripts/hook/robustness/concurrent-writes.txtar
@@ -53,7 +53,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24; do
   fi
 done
 exit 0
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed

--- a/test/acceptance/scripts/hook/robustness/malformed-input-never-blocks.txtar
+++ b/test/acceptance/scripts/hook/robustness/malformed-input-never-blocks.txtar
@@ -38,7 +38,7 @@ stderr 'failed to parse event'
 this is not json {{{
 -- unknown_type.json --
 {"session_id":"s1","hook_event_name":"NoSuchHookType"}
--- home2/.config/gryph/config.yaml --
+-- home2/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed

--- a/test/acceptance/scripts/install/claude-code/hooks-written.txtar
+++ b/test/acceptance/scripts/install/claude-code/hooks-written.txtar
@@ -15,7 +15,7 @@ grep 'echo pre-existing-hook' $HOME/.claude/settings.json
 grep '"theme": *"dark"' $HOME/.claude/settings.json
 
 # The database and config directories exist inside the sandbox.
-exists $XDG_DATA_HOME/gryph/audit.db
+exists $XDG_DATA_HOME/safedep/gryph/audit.db
 
 -- home/.claude/settings.json --
 {

--- a/test/acceptance/scripts/install/purge/data-removed.txtar
+++ b/test/acceptance/scripts/install/purge/data-removed.txtar
@@ -6,18 +6,18 @@ env XDG_DATA_HOME=$WORK/home/.local/share
 
 exec gryph install --agent claude-code
 exec gryph config set logging.level full
-exists $XDG_DATA_HOME/gryph/audit.db
-exists $XDG_CONFIG_HOME/gryph/config.yaml
+exists $XDG_DATA_HOME/safedep/gryph/audit.db
+exists $XDG_CONFIG_HOME/safedep/gryph/config.yml
 
 exec gryph uninstall --purge --dry-run
-exists $XDG_DATA_HOME/gryph/audit.db
-exists $XDG_CONFIG_HOME/gryph/config.yaml
+exists $XDG_DATA_HOME/safedep/gryph/audit.db
+exists $XDG_CONFIG_HOME/safedep/gryph/config.yml
 grep 'gryph _hook' $HOME/.claude/settings.json
 
 exec gryph uninstall --purge
 stdout 'Database and config files have been removed.'
-! exists $XDG_DATA_HOME/gryph/audit.db
-! exists $XDG_CONFIG_HOME/gryph/config.yaml
+! exists $XDG_DATA_HOME/safedep/gryph/audit.db
+! exists $XDG_CONFIG_HOME/safedep/gryph/config.yml
 ! grep 'gryph _hook' $HOME/.claude/settings.json
 grep 'echo pre-existing-hook' $HOME/.claude/settings.json
 

--- a/test/acceptance/scripts/install/uninstall/round-trip.txtar
+++ b/test/acceptance/scripts/install/uninstall/round-trip.txtar
@@ -6,7 +6,7 @@ env XDG_DATA_HOME=$WORK/home/.local/share
 
 exec gryph install --agent claude-code
 grep 'gryph _hook' $HOME/.claude/settings.json
-exists $XDG_DATA_HOME/gryph/backups/claude-code
+exists $XDG_DATA_HOME/safedep/gryph/backups/claude-code
 
 exec gryph uninstall --agent claude-code
 ! grep 'gryph _hook' $HOME/.claude/settings.json

--- a/test/acceptance/scripts/migration/layout/both-exist-new-wins.txtar
+++ b/test/acceptance/scripts/migration/layout/both-exist-new-wins.txtar
@@ -1,0 +1,18 @@
+# When the legacy and the new config directory both exist, gryph reads the
+# new one and leaves the legacy directory in place for manual
+# reconciliation. Nothing is merged and nothing is deleted.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+exec gryph config get logging.level
+stdout 'minimal'
+exists $XDG_CONFIG_HOME/gryph/config.yaml
+exists $XDG_CONFIG_HOME/safedep/gryph/config.yml
+
+-- home/.config/gryph/config.yaml --
+logging:
+  level: full
+-- home/.config/safedep/gryph/config.yml --
+logging:
+  level: minimal

--- a/test/acceptance/scripts/migration/layout/env-override-normalizes.txtar
+++ b/test/acceptance/scripts/migration/layout/env-override-normalizes.txtar
@@ -1,0 +1,16 @@
+# GRYPH_CONFIG_DIR names the final config directory with no safedep/gryph
+# leaf appended. The directory never moves, and a config.yaml inside it is
+# still renamed to config.yml.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+env GRYPH_CONFIG_DIR=$WORK/cfg
+
+exec gryph config get logging.level
+stdout 'full'
+exists $WORK/cfg/config.yml
+! exists $WORK/cfg/config.yaml
+
+-- cfg/config.yaml --
+logging:
+  level: full

--- a/test/acceptance/scripts/migration/layout/legacy-tree-moves.txtar
+++ b/test/acceptance/scripts/migration/layout/legacy-tree-moves.txtar
@@ -1,0 +1,30 @@
+# An install from a release before the safedep/gryph layout moves to the
+# new location on first run. The config keeps loading, the stored state
+# stays intact, and the move leaves a path_migration self-log row.
+env HOME=$WORK/home
+env XDG_CONFIG_HOME=$WORK/home/.config
+env XDG_DATA_HOME=$WORK/home/.local/share
+
+# The seeded legacy config sets a non-default logging level. Reading it back
+# proves the moved config loads from the new location.
+exec gryph config get logging.level
+stdout 'full'
+exists $XDG_CONFIG_HOME/safedep/gryph/config.yml
+! exists $XDG_CONFIG_HOME/safedep/gryph/config.yaml
+exists $XDG_CONFIG_HOME/safedep/gryph/policy.yaml
+exists $XDG_DATA_HOME/safedep/gryph/keep.txt
+! exists $XDG_CONFIG_HOME/gryph
+! exists $XDG_DATA_HOME/gryph
+
+# The first command that opens the store records the migration.
+exec gryph self-log --format json --no-color
+stdout '"Action": "path_migration"'
+
+-- home/.config/gryph/config.yaml --
+logging:
+  level: full
+-- home/.config/gryph/policy.yaml --
+version: 1
+rules: []
+-- home/.local/share/gryph/keep.txt --
+audit data placeholder

--- a/test/acceptance/scripts/policy/authoring/duplicate-rule-id-refused.txtar
+++ b/test/acceptance/scripts/policy/authoring/duplicate-rule-id-refused.txtar
@@ -12,13 +12,13 @@ stdout 'File valid'
 # The merge check refuses it.
 execexit 2 gryph policy install dup.yaml --no-color
 stderr 'duplicate rule id'
-! exists $XDG_CONFIG_HOME/gryph/policies/dup.yaml
+! exists $XDG_CONFIG_HOME/safedep/gryph/policies/dup.yaml
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: global-block-npm

--- a/test/acceptance/scripts/policy/authoring/install-multi-file.txtar
+++ b/test/acceptance/scripts/policy/authoring/install-multi-file.txtar
@@ -10,7 +10,7 @@ stdout 'File valid: 1 rules'
 
 exec gryph policy install draft.yaml --no-color
 stdout 'Installed to'
-exists $XDG_CONFIG_HOME/gryph/policies/draft.yaml
+exists $XDG_CONFIG_HOME/safedep/gryph/policies/draft.yaml
 
 exec gryph policy list --no-color
 stdout 'policies\s+draft.yaml\s+1'
@@ -21,7 +21,7 @@ stdin bash_curl.json
 execexit 2 gryph _hook claude-code PreToolUse
 stderr 'blocked-by-draft'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed

--- a/test/acceptance/scripts/policy/block/dangerous-command.txtar
+++ b/test/acceptance/scripts/policy/block/dangerous-command.txtar
@@ -17,12 +17,12 @@ stdout 'blocked-by-acceptance'
 exec gryph query --status blocked --format json --no-color
 stdout -count=2 '"ResultStatus": "blocked"'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
   log_all_evaluations: true
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-block-npm-install

--- a/test/acceptance/scripts/policy/context/chain-verifies-clean.txtar
+++ b/test/acceptance/scripts/policy/context/chain-verifies-clean.txtar
@@ -17,12 +17,12 @@ exec gryph policy context --verify --all-sessions --no-color
 stdout 'Context chain verification: OK'
 stdout 'ok=3 broken=0 unchained=0'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
   log_all_evaluations: true
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-block-npm-install

--- a/test/acceptance/scripts/policy/context/counter-condition-fires.txtar
+++ b/test/acceptance/scripts/policy/context/counter-condition-fires.txtar
@@ -22,11 +22,11 @@ stderr 'blocked-by-counter'
 exec gryph query --status blocked --format json --no-color
 stdout -count=2 '"ResultStatus": "blocked"'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-cap-writes

--- a/test/acceptance/scripts/policy/defer/timeout-resolves-deny.txtar
+++ b/test/acceptance/scripts/policy/defer/timeout-resolves-deny.txtar
@@ -29,14 +29,14 @@ stdout 'Swept 1 expired'
 exec gryph policy deferrals --status resolved_timeout --format json --no-color
 stdout '"status": "resolved_timeout"'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
   defer:
     enabled: true
     timeout_seconds: 600
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-defer-npm
@@ -46,14 +46,14 @@ rules:
       action_types: [command_exec]
       command_patterns:
         - "(?i)\\bnpm\\s+install\\b"
--- home2/.config/gryph/config.yaml --
+-- home2/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
   defer:
     enabled: true
     timeout_seconds: 1
--- home2/.config/gryph/policy.yaml --
+-- home2/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-defer-npm

--- a/test/acceptance/scripts/policy/dry-run/matches-enforcement.txtar
+++ b/test/acceptance/scripts/policy/dry-run/matches-enforcement.txtar
@@ -18,11 +18,11 @@ stdout 'ALLOW'
 stdin bash_gotest.json
 exec gryph _hook claude-code PreToolUse
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-block-npm-install

--- a/test/acceptance/scripts/policy/enrichment/classification-and-injection-block.txtar
+++ b/test/acceptance/scripts/policy/enrichment/classification-and-injection-block.txtar
@@ -28,11 +28,11 @@ stdin mcp_injected.json
 execexit 2 gryph _hook claude-code PreToolUse
 stderr 'blocked-by-injection-score'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: block-cmd-after-secret-read

--- a/test/acceptance/scripts/policy/escalate/nop-fails-closed.txtar
+++ b/test/acceptance/scripts/policy/escalate/nop-fails-closed.txtar
@@ -17,11 +17,11 @@ exec gryph self-log --format json --no-color
 stdout '"Action": "approval_requested"'
 stdout '"Action": "approval_denied"'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-escalate-npm

--- a/test/acceptance/scripts/policy/fail-mode/closed-on-broken-policy.txtar
+++ b/test/acceptance/scripts/policy/fail-mode/closed-on-broken-policy.txtar
@@ -18,20 +18,20 @@ env XDG_DATA_HOME=$WORK/home2/.local/share
 stdin bash_npm.json
 exec gryph _hook claude-code PreToolUse
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: broken-rule
     action: nosuchdecision
--- home2/.config/gryph/config.yaml --
+-- home2/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: open
--- home2/.config/gryph/policy.yaml --
+-- home2/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: broken-rule

--- a/test/acceptance/scripts/policy/guidance/advisory-delivered.txtar
+++ b/test/acceptance/scripts/policy/guidance/advisory-delivered.txtar
@@ -18,11 +18,11 @@ exec gryph query --format json --no-color
 stdout -count=2 '"ResultStatus": "success"'
 ! stdout '"ResultStatus": "blocked"'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-guide-readme

--- a/test/acceptance/scripts/policy/precedence/block-beats-allow.txtar
+++ b/test/acceptance/scripts/policy/precedence/block-beats-allow.txtar
@@ -15,11 +15,11 @@ stdin bash_npm.json
 execexit 2 gryph _hook claude-code PreToolUse
 stderr 'blocked-by-global'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: global-block-npm
@@ -30,7 +30,7 @@ rules:
       command_patterns:
         - "(?i)\\bnpm\\s+install\\b"
     message: "blocked-by-global"
--- home/.config/gryph/policies/permissive.yaml --
+-- home/.config/safedep/gryph/policies/permissive.yaml --
 version: "1"
 rules:
   - id: permissive-allow-all

--- a/test/acceptance/scripts/policy/self-protection/config-write-blocked.txtar
+++ b/test/acceptance/scripts/policy/self-protection/config-write-blocked.txtar
@@ -18,7 +18,7 @@ stderr 'self-protection'
 exec gryph query --status blocked --format json --no-color
 stdout -count=2 '"ResultStatus": "blocked"'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
@@ -29,7 +29,7 @@ policy:
   "hook_event_name": "PreToolUse",
   "tool_name": "Write",
   "tool_input": {
-    "file_path": "${XDG_CONFIG_HOME}/gryph/policy.yaml",
+    "file_path": "${XDG_CONFIG_HOME}/safedep/gryph/policy.yaml",
     "content": "version: \"1\"\nrules: []\n"
   },
   "tool_use_id": "tool-use-sp1"

--- a/test/acceptance/scripts/privacy/sensitive/content-never-stored.txtar
+++ b/test/acceptance/scripts/privacy/sensitive/content-never-stored.txtar
@@ -27,7 +27,7 @@ stdout '"is_sensitive":true'
 ! stdout 'hunter2'
 stderr 'Exported 1 events'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 logging:
   level: full
 -- write_env.json --

--- a/test/acceptance/scripts/receipts/signing/key-round-trip.txtar
+++ b/test/acceptance/scripts/receipts/signing/key-round-trip.txtar
@@ -7,8 +7,8 @@ env XDG_DATA_HOME=$WORK/home/.local/share
 
 exec gryph policy keys generate --no-color
 stdout 'Generated key'
-exists $XDG_CONFIG_HOME/gryph/keys/receipt.key
-exists $XDG_CONFIG_HOME/gryph/keys/receipt-pub.json
+exists $XDG_CONFIG_HOME/safedep/gryph/keys/receipt.key
+exists $XDG_CONFIG_HOME/safedep/gryph/keys/receipt-pub.json
 
 stdin read_allow.json
 exec gryph _hook claude-code PreToolUse
@@ -27,12 +27,12 @@ execexit 2 gryph policy receipts verify-log --input signed.jsonl --no-color
 stdout 'signed_invalid\s+1'
 stderr 'invalid signature'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
   log_all_evaluations: true
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-block-npm-install

--- a/test/acceptance/scripts/receipts/verify-log/tamper-fails.txtar
+++ b/test/acceptance/scripts/receipts/verify-log/tamper-fails.txtar
@@ -21,12 +21,12 @@ replace receipts.jsonl '"decision":"block"' '"decision":"allow"'
 execexit 2 gryph policy receipts verify-log --input receipts.jsonl
 stderr 'chain break'
 
--- home/.config/gryph/config.yaml --
+-- home/.config/safedep/gryph/config.yml --
 policy:
   enabled: true
   fail_mode: closed
   log_all_evaluations: true
--- home/.config/gryph/policy.yaml --
+-- home/.config/safedep/gryph/policy.yaml --
 version: "1"
 rules:
   - id: acceptance-block-npm-install

--- a/test/acceptance/scripts/storage/upgrade/previous-release-db-opens.txtar
+++ b/test/acceptance/scripts/storage/upgrade/previous-release-db-opens.txtar
@@ -6,8 +6,8 @@ env HOME=$WORK/home
 env XDG_CONFIG_HOME=$WORK/home/.config
 env XDG_DATA_HOME=$WORK/home/.local/share
 
-mkdir $XDG_DATA_HOME/gryph
-cp $ACCEPTANCE_TESTDATA/upgrade/audit-v0.7.0.db $XDG_DATA_HOME/gryph/audit.db
+mkdir $XDG_DATA_HOME/safedep/gryph
+cp $ACCEPTANCE_TESTDATA/upgrade/audit-v0.7.0.db $XDG_DATA_HOME/safedep/gryph/audit.db
 
 exec gryph query --format json --no-color
 stdout -count=4 '"ActionType"'

--- a/test/cli/e2e_helpers_test.go
+++ b/test/cli/e2e_helpers_test.go
@@ -48,7 +48,7 @@ func newTestEnvWithPolicy(t *testing.T, policyYAML string) *testEnv {
 	// config directory at a temp location via XDG_CONFIG_HOME and seed the
 	// policy there.
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
-	configDir := filepath.Join(tmpDir, "gryph")
+	configDir := filepath.Join(tmpDir, "safedep", "gryph")
 	require.NoError(t, os.MkdirAll(configDir, 0o755))
 	policyPath := filepath.Join(configDir, "policy.yaml")
 	require.NoError(t, os.WriteFile(policyPath, []byte(policyYAML), 0o600))


### PR DESCRIPTION
## What

Gryph stores its config, data, and cache under a bare `gryph` leaf. Every other SafeDep tool uses the shared `safedep` namespace. This change moves Gryph to `safedep/gryph` and adopts four patterns PMG already uses.

### Path resolution (`config/paths.go`)

One shared resolver order for config, data, and cache:

1. `GRYPH_CONFIG_DIR` / `GRYPH_DATA_DIR` / `GRYPH_CACHE_DIR` name the final directory, with no leaf appended. Useful for tests, CI, and containers.
2. A sudo elevation guard (`euid == 0` and `SUDO_USER` set) resolves the base from root's passwd home. This stops an elevated run from writing root-owned files into the invoking user's home.
3. `XDG_CONFIG_HOME` / `XDG_DATA_HOME` / `XDG_CACHE_HOME` stay honored on all platforms. A relative value is ignored, as the XDG spec requires. This is a deliberate divergence from PMG.
4. The platform default (`os.UserConfigDir`, the standard data base, `os.UserCacheDir`).

The old preexisting-directory checks are removed. The migration ends their purpose.

### System managed config (`config/system.go`)

A root-owned `config.yml` at `/etc/safedep/gryph` (Linux), `/Library/Application Support/safedep/gryph` (macOS), or `%PROGRAMDATA%\safedep\gryph` (Windows) is authoritative when present: it wins over an explicit `--config` path and over the per-user file, matching PMG. On Unix the file must be root-owned and not group or world writable, or it is ignored with a warning. While active, `gryph config set` and `gryph config reset` refuse with a clear error, `gryph config show` and `gryph config get` report the managed values, and `gryph doctor` shows the managed file. There is no env var or flag for this location, so a user cannot point it at a file they own. The directory layout mirrors the per-user config directory, reserving `policy.yaml`, `policies/`, and `keys/receipt-pub.json` for a future managed policy.

Known limits, by design for now: `GRYPH_*` config value env vars still beat the managed file (a PMG-style `global_lockdown` is follow-up work), and Windows accepts the file without an ACL check (parity with PMG; an ACL check must land before the managed directory carries policy).

### Config file name

`config.yml` replaces `config.yaml`, matching PMG. Viper prefers the `yaml` extension, so the two names must never coexist. The migration renames the file, and the config manager removes a stale `config.yaml` sibling after writing `config.yml`.

### One-time migration (`config/migrate.go`)

`config.Load` and `EnsureDirectories` trigger it. The fast path is a few stat calls, so the agent hook path stays cheap.

- Legacy paths come only from the retained old resolvers, so XDG layouts migrate correctly.
- `os.Rename` moves config and data. The cache directory holds nothing, so it is not migrated. Only an empty legacy cache directory is removed.
- Config and data can resolve to one pair (macOS default), which moves once.
- An env override skips the move for that kind. The file-name normalization still runs.
- When both directories exist, the new one wins and the legacy one is left in place with one warning.
- A lost rename race against a concurrent hook process is a no-op. Any other failure warns and continues, so a migration problem never breaks the agent.
- An elevated (sudo) run never moves the invoking user's files.

The migration hands its result to the CLI through a marker file in the data directory. The first store-opening command consumes it and records a `path_migration` self-audit entry.

### Compatibility

- Forward migration is automatic and loses no data. XDG users see only the leaf change.
- Downgrade after migration is a known limit: an old binary starts a fresh tree at the legacy path. Recovery is a manual move back or a re-upgrade.

## Testing

- Unit tests: resolvers (overrides, XDG on all platforms, relative XDG, sudo guard and its passwd fallback), managed config precedence and trust, the Viper env collision, the full migration matrix, and the manager's stale-sibling removal.
- Acceptance: existing scripts updated to the new layout, plus three new guarantees with catalog rows: `migration/layout/legacy-tree-moves` (P0), `migration/layout/env-override-normalizes` (P1), `migration/layout/both-exist-new-wins` (P1).
- `make lint`, `go test ./... -count=1`, `make verify-schema`, and the full acceptance suite pass locally.

The release notes must call out the one-time move and the downgrade limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7zD7xFzZk4UFGZcDctzP3