### PR TITLE
Decouple agent adapters from the CLI, config, and tui layers

### DIFF
--- a/agent/adapter.go
+++ b/agent/adapter.go
@@ -19,42 +19,6 @@ const (
 	AgentCodex      = "codex"
 )
 
-// Standard agent display names.
-const (
-	DisplayClaudeCode = "Claude Code"
-	DisplayCursor     = "Cursor"
-	DisplayGemini     = "Gemini CLI"
-	DisplayOpenCode   = "OpenCode"
-	DisplayOpenClaw   = "OpenClaw"
-	DisplayWindsurf   = "Windsurf"
-	DisplayPiAgent    = "Pi Agent"
-	DisplayCodex      = "Codex"
-)
-
-// AgentDisplayName returns the display name for an agent identifier.
-func AgentDisplayName(name string) string {
-	switch name {
-	case AgentClaudeCode:
-		return DisplayClaudeCode
-	case AgentCursor:
-		return DisplayCursor
-	case AgentGemini:
-		return DisplayGemini
-	case AgentOpenCode:
-		return DisplayOpenCode
-	case AgentOpenClaw:
-		return DisplayOpenClaw
-	case AgentWindsurf:
-		return DisplayWindsurf
-	case AgentPiAgent:
-		return DisplayPiAgent
-	case AgentCodex:
-		return DisplayCodex
-	default:
-		return name
-	}
-}
-
 // DetectionResult contains information about a detected agent.
 type DetectionResult struct {
 	// Installed indicates if the agent is installed.

--- a/agent/adapter.go
+++ b/agent/adapter.go
@@ -95,6 +95,46 @@ type HookStatus struct {
 	Issues []string
 }
 
+// HookDecision is the three-valued outcome the CLI maps from the security
+// evaluator before it renders a response.
+type HookDecision int
+
+const (
+	// DecisionAllow lets the action proceed.
+	DecisionAllow HookDecision = iota
+	// DecisionBlock stops the action with a reason.
+	DecisionBlock
+	// DecisionGuidance lets the action proceed with advisory text.
+	DecisionGuidance
+)
+
+// HookResponse is the transport-neutral result of a hook decision. The CLI
+// performs the IO: it writes Stdout, and it routes Stderr on one channel
+// only. A non-zero exit carries the text in the exit error, which main
+// writes. A zero exit writes the text directly.
+type HookResponse interface {
+	// Stdout returns the bytes to write to stdout, or nil.
+	Stdout() []byte
+	// Stderr returns the block reason or advisory text, or "".
+	Stderr() string
+	// ExitCode returns 0 for allow, 1 for a non-blocking error, 2 for block.
+	ExitCode() int
+}
+
+// RenderedResponse is a plain HookResponse value adapters return from
+// RenderResponse.
+type RenderedResponse struct {
+	Out  []byte
+	Err  string
+	Code int
+}
+
+func (r RenderedResponse) Stdout() []byte { return r.Out }
+
+func (r RenderedResponse) Stderr() string { return r.Err }
+
+func (r RenderedResponse) ExitCode() int { return r.Code }
+
 // Adapter defines the interface for agent integrations.
 type Adapter interface {
 	// Name returns the machine identifier (e.g., "claude-code").
@@ -117,4 +157,10 @@ type Adapter interface {
 
 	// ParseEvent converts an agent-specific event to the common format.
 	ParseEvent(ctx context.Context, hookType string, rawData []byte) (*events.Event, error)
+
+	// RenderResponse maps a decision to this agent's wire response for the
+	// given hook type. The adapter owns the per-hook-type knowledge: whether
+	// stdout carries JSON, what the exit code is, and when text routes to
+	// stderr.
+	RenderResponse(hookType string, decision HookDecision, detail string) HookResponse
 }

--- a/agent/claudecode/adapter.go
+++ b/agent/claudecode/adapter.go
@@ -63,6 +63,22 @@ func (a *Adapter) ParseEvent(ctx context.Context, hookType string, rawData []byt
 	return a.parseHookEvent(hookType, rawData)
 }
 
+// RenderResponse maps a decision to the Claude Code wire response. Claude
+// Code has no JSON channel. Block is exit 2 with the reason on stderr,
+// shown to Claude. Guidance is exit 0 with advisory text on stderr.
+func (a *Adapter) RenderResponse(hookType string, decision agent.HookDecision, detail string) agent.HookResponse {
+	var r *HookResponse
+	switch decision {
+	case agent.DecisionBlock:
+		r = NewBlockResponse(detail)
+	case agent.DecisionGuidance:
+		r = NewGuidanceResponse(detail)
+	default:
+		r = NewAllowResponse()
+	}
+	return agent.RenderedResponse{Err: r.Stderr(), Code: r.ExitCode()}
+}
+
 // Register adds this adapter to the given registry.
 func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, loggingLevel config.LoggingLevel, contentHash bool) {
 	registry.Register(New(privacyChecker, loggingLevel, contentHash))

--- a/agent/claudecode/adapter.go
+++ b/agent/claudecode/adapter.go
@@ -13,7 +13,7 @@ const (
 	// AgentName is the machine identifier for Claude Code.
 	AgentName = agent.AgentClaudeCode
 	// DisplayName is the human-readable name for Claude Code.
-	DisplayName = agent.DisplayClaudeCode
+	DisplayName = "Claude Code"
 )
 
 // Adapter implements the agent.Adapter interface for Claude Code.

--- a/agent/claudecode/render_test.go
+++ b/agent/claudecode/render_test.go
@@ -1,0 +1,37 @@
+package claudecode
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderResponse(t *testing.T) {
+	a := New(nil, "", false)
+
+	tests := []struct {
+		name     string
+		hookType string
+		decision agent.HookDecision
+		detail   string
+		wantOut  []byte
+		wantErr  string
+		wantCode int
+	}{
+		{"allow pre hook", "PreToolUse", agent.DecisionAllow, "", nil, "", 0},
+		{"allow post hook", "PostToolUse", agent.DecisionAllow, "", nil, "", 0},
+		{"block pre hook", "PreToolUse", agent.DecisionBlock, "blocked reason", nil, "blocked reason", 2},
+		{"guidance pre hook", "PreToolUse", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+		{"guidance post hook", "PostToolUse", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := a.RenderResponse(tt.hookType, tt.decision, tt.detail)
+			assert.Equal(t, tt.wantOut, resp.Stdout())
+			assert.Equal(t, tt.wantErr, resp.Stderr())
+			assert.Equal(t, tt.wantCode, resp.ExitCode())
+		})
+	}
+}

--- a/agent/codex/adapter.go
+++ b/agent/codex/adapter.go
@@ -51,3 +51,31 @@ func (a *Adapter) ParseEvent(ctx context.Context, hookType string, rawData []byt
 func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, loggingLevel config.LoggingLevel, contentHash bool) {
 	registry.Register(New(privacyChecker, loggingLevel, contentHash))
 }
+
+// blockingHookType is the one hook with a JSON decision channel.
+const blockingHookType = "PreToolUse"
+
+// RenderResponse maps a decision to the wire response. The blocking hook
+// carries a JSON decision on stdout. Allow on other hooks emits nothing.
+// Guidance on other hooks routes advisory text to stderr at exit 0. Block
+// is exit 2 with the reason on stderr.
+func (a *Adapter) RenderResponse(hookType string, decision agent.HookDecision, detail string) agent.HookResponse {
+	jsonHook := hookType == blockingHookType
+	switch decision {
+	case agent.DecisionBlock:
+		r := NewBlockResponse(detail)
+		resp := agent.RenderedResponse{Err: r.Stderr(), Code: r.ExitCode()}
+		if jsonHook {
+			resp.Out = r.JSON()
+		}
+		return resp
+	case agent.DecisionGuidance:
+		r := NewGuidanceResponse(detail)
+		if jsonHook {
+			return agent.RenderedResponse{Out: r.JSON()}
+		}
+		return agent.RenderedResponse{Err: r.Stderr()}
+	default:
+		return agent.RenderedResponse{}
+	}
+}

--- a/agent/codex/adapter.go
+++ b/agent/codex/adapter.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	AgentName   = agent.AgentCodex
-	DisplayName = agent.DisplayCodex
+	DisplayName = "Codex"
 )
 
 var _ agent.Adapter = (*Adapter)(nil)

--- a/agent/codex/render_test.go
+++ b/agent/codex/render_test.go
@@ -1,0 +1,38 @@
+package codex
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderResponse(t *testing.T) {
+	a := New(nil, "", false)
+
+	tests := []struct {
+		name     string
+		hookType string
+		decision agent.HookDecision
+		detail   string
+		wantOut  []byte
+		wantErr  string
+		wantCode int
+	}{
+		{"allow blocking hook", "PreToolUse", agent.DecisionAllow, "", nil, "", 0},
+		{"allow other hook", "PostToolUse", agent.DecisionAllow, "", nil, "", 0},
+		{"block blocking hook", "PreToolUse", agent.DecisionBlock, "reason", NewBlockResponse("reason").JSON(), "reason", 2},
+		{"block other hook", "PostToolUse", agent.DecisionBlock, "reason", nil, "reason", 2},
+		{"guidance blocking hook", "PreToolUse", agent.DecisionGuidance, "advisory", NewGuidanceResponse("advisory").JSON(), "", 0},
+		{"guidance other hook", "PostToolUse", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := a.RenderResponse(tt.hookType, tt.decision, tt.detail)
+			assert.Equal(t, tt.wantOut, resp.Stdout())
+			assert.Equal(t, tt.wantErr, resp.Stderr())
+			assert.Equal(t, tt.wantCode, resp.ExitCode())
+		})
+	}
+}

--- a/agent/cursor/adapter.go
+++ b/agent/cursor/adapter.go
@@ -63,6 +63,71 @@ func (a *Adapter) ParseEvent(ctx context.Context, hookType string, rawData []byt
 	return a.parseHookEvent(hookType, rawData)
 }
 
+// RenderResponse maps a decision to the Cursor wire response. Cursor reads
+// JSON on stdout for every hook and never uses exit codes. Each hook type
+// has its own response schema.
+func (a *Adapter) RenderResponse(hookType string, decision agent.HookDecision, detail string) agent.HookResponse {
+	switch decision {
+	case agent.DecisionBlock:
+		return agent.RenderedResponse{
+			Out: renderDecisionResponse(hookType, NewDenyResponse(detail), false),
+		}
+	case agent.DecisionGuidance:
+		r := NewGuidanceResponse(detail)
+		resp := agent.RenderedResponse{
+			Out: renderDecisionResponse(hookType, r, true),
+		}
+		// preToolUse JSON carries decision=allow with no reason field, so
+		// the advisory text routes to stderr.
+		if hookType == "preToolUse" && r.Reason != "" {
+			resp.Err = r.Reason
+		}
+		return resp
+	default:
+		return agent.RenderedResponse{Out: renderAllowResponse(hookType)}
+	}
+}
+
+// renderDecisionResponse builds the JSON response for a hook type carrying
+// an explicit deny (cont=false) or allow-with-advisory (cont=true) decision.
+func renderDecisionResponse(hookType string, response *HookResponse, cont bool) []byte {
+	switch hookType {
+	case "preToolUse":
+		return GeneratePreToolUseResponse(response)
+
+	case "beforeShellExecution", "beforeMCPExecution", "beforeReadFile", "beforeTabFileRead":
+		return GeneratePermissionResponse(response)
+
+	case "beforeSubmitPrompt", "sessionStart":
+		return GenerateContinueResponse(cont, response.Reason)
+
+	default:
+		return []byte("{}")
+	}
+}
+
+// renderAllowResponse builds the JSON response for the plain allow path.
+func renderAllowResponse(hookType string) []byte {
+	allowResponse := NewAllowResponse()
+
+	switch hookType {
+	case "preToolUse":
+		return GeneratePreToolUseResponse(allowResponse)
+
+	case "beforeShellExecution", "beforeMCPExecution", "beforeReadFile", "beforeTabFileRead":
+		return GeneratePermissionResponse(allowResponse)
+
+	case "beforeSubmitPrompt", "sessionStart":
+		return GenerateContinueResponse(true, "")
+
+	case "stop", "subagentStop":
+		return GenerateStopResponse("")
+
+	default:
+		return []byte("{}")
+	}
+}
+
 // Register adds this adapter to the given registry.
 func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, loggingLevel config.LoggingLevel, contentHash bool) {
 	registry.Register(New(privacyChecker, loggingLevel, contentHash))

--- a/agent/cursor/adapter.go
+++ b/agent/cursor/adapter.go
@@ -13,7 +13,7 @@ const (
 	// AgentName is the machine identifier for Cursor.
 	AgentName = agent.AgentCursor
 	// DisplayName is the human-readable name for Cursor.
-	DisplayName = agent.DisplayCursor
+	DisplayName = "Cursor"
 )
 
 // Adapter implements the agent.Adapter interface for Cursor.

--- a/agent/cursor/render_test.go
+++ b/agent/cursor/render_test.go
@@ -1,0 +1,79 @@
+package cursor
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderResponse(t *testing.T) {
+	a := New(nil, "", false)
+
+	tests := []struct {
+		name     string
+		hookType string
+		decision agent.HookDecision
+		detail   string
+		wantOut  []byte
+		wantErr  string
+	}{
+		{
+			"allow preToolUse", "preToolUse", agent.DecisionAllow, "",
+			GeneratePreToolUseResponse(NewAllowResponse()), "",
+		},
+		{
+			"allow permission hook", "beforeShellExecution", agent.DecisionAllow, "",
+			GeneratePermissionResponse(NewAllowResponse()), "",
+		},
+		{
+			"allow continue hook", "beforeSubmitPrompt", agent.DecisionAllow, "",
+			GenerateContinueResponse(true, ""), "",
+		},
+		{
+			"allow stop hook", "stop", agent.DecisionAllow, "",
+			GenerateStopResponse(""), "",
+		},
+		{
+			"allow post hook", "afterFileEdit", agent.DecisionAllow, "",
+			[]byte("{}"), "",
+		},
+		{
+			"block preToolUse", "preToolUse", agent.DecisionBlock, "reason",
+			GeneratePreToolUseResponse(NewDenyResponse("reason")), "",
+		},
+		{
+			"block permission hook", "beforeReadFile", agent.DecisionBlock, "reason",
+			GeneratePermissionResponse(NewDenyResponse("reason")), "",
+		},
+		{
+			"block continue hook", "sessionStart", agent.DecisionBlock, "reason",
+			GenerateContinueResponse(false, "reason"), "",
+		},
+		{
+			"block post hook", "afterFileEdit", agent.DecisionBlock, "reason",
+			[]byte("{}"), "",
+		},
+		{
+			"guidance preToolUse routes text to stderr", "preToolUse", agent.DecisionGuidance, "advisory",
+			GeneratePreToolUseResponse(NewGuidanceResponse("advisory")), "advisory",
+		},
+		{
+			"guidance permission hook", "beforeMCPExecution", agent.DecisionGuidance, "advisory",
+			GeneratePermissionResponse(NewGuidanceResponse("advisory")), "",
+		},
+		{
+			"guidance continue hook", "beforeSubmitPrompt", agent.DecisionGuidance, "advisory",
+			GenerateContinueResponse(true, "advisory"), "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := a.RenderResponse(tt.hookType, tt.decision, tt.detail)
+			assert.Equal(t, tt.wantOut, resp.Stdout())
+			assert.Equal(t, tt.wantErr, resp.Stderr())
+			assert.Equal(t, 0, resp.ExitCode())
+		})
+	}
+}

--- a/agent/gemini/adapter.go
+++ b/agent/gemini/adapter.go
@@ -56,3 +56,34 @@ func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, l
 }
 
 var _ agent.Adapter = (*Adapter)(nil)
+
+// blockingHookType is the one Gemini CLI hook with a JSON decision channel.
+const blockingHookType = "BeforeTool"
+
+// RenderResponse maps a decision to the Gemini CLI wire response. BeforeTool
+// carries a JSON decision on stdout. Other hooks receive an empty JSON
+// object on allow and advisory text on stderr for guidance. Block is exit 2
+// with the reason on stderr.
+func (a *Adapter) RenderResponse(hookType string, decision agent.HookDecision, detail string) agent.HookResponse {
+	jsonHook := hookType == blockingHookType
+	switch decision {
+	case agent.DecisionBlock:
+		r := NewBlockResponse(detail)
+		resp := agent.RenderedResponse{Err: r.Stderr(), Code: r.ExitCode()}
+		if jsonHook {
+			resp.Out = r.JSON()
+		}
+		return resp
+	case agent.DecisionGuidance:
+		r := NewGuidanceResponse(detail)
+		if jsonHook {
+			return agent.RenderedResponse{Out: r.JSON()}
+		}
+		return agent.RenderedResponse{Err: r.Stderr()}
+	default:
+		if jsonHook {
+			return agent.RenderedResponse{Out: NewAllowResponse().JSON()}
+		}
+		return agent.RenderedResponse{Out: []byte("{}")}
+	}
+}

--- a/agent/gemini/adapter.go
+++ b/agent/gemini/adapter.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	AgentName   = agent.AgentGemini
-	DisplayName = agent.DisplayGemini
+	DisplayName = "Gemini CLI"
 )
 
 type Adapter struct {

--- a/agent/gemini/render_test.go
+++ b/agent/gemini/render_test.go
@@ -1,0 +1,38 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderResponse(t *testing.T) {
+	a := New(nil, "", false)
+
+	tests := []struct {
+		name     string
+		hookType string
+		decision agent.HookDecision
+		detail   string
+		wantOut  []byte
+		wantErr  string
+		wantCode int
+	}{
+		{"allow BeforeTool", "BeforeTool", agent.DecisionAllow, "", NewAllowResponse().JSON(), "", 0},
+		{"allow other hook", "AfterTool", agent.DecisionAllow, "", []byte("{}"), "", 0},
+		{"block BeforeTool", "BeforeTool", agent.DecisionBlock, "reason", NewBlockResponse("reason").JSON(), "reason", 2},
+		{"block other hook", "AfterTool", agent.DecisionBlock, "reason", nil, "reason", 2},
+		{"guidance BeforeTool", "BeforeTool", agent.DecisionGuidance, "advisory", NewGuidanceResponse("advisory").JSON(), "", 0},
+		{"guidance other hook", "AfterTool", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := a.RenderResponse(tt.hookType, tt.decision, tt.detail)
+			assert.Equal(t, tt.wantOut, resp.Stdout())
+			assert.Equal(t, tt.wantErr, resp.Stderr())
+			assert.Equal(t, tt.wantCode, resp.ExitCode())
+		})
+	}
+}

--- a/agent/openclaw/adapter.go
+++ b/agent/openclaw/adapter.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	AgentName   = agent.AgentOpenClaw
-	DisplayName = agent.DisplayOpenClaw
+	DisplayName = "OpenClaw"
 )
 
 type Adapter struct {

--- a/agent/openclaw/adapter.go
+++ b/agent/openclaw/adapter.go
@@ -56,3 +56,31 @@ func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, l
 }
 
 var _ agent.Adapter = (*Adapter)(nil)
+
+// blockingHookType is the one hook with a JSON decision channel.
+const blockingHookType = "before_tool_call"
+
+// RenderResponse maps a decision to the wire response. The blocking hook
+// carries a JSON decision on stdout. Allow on other hooks emits nothing.
+// Guidance on other hooks routes advisory text to stderr at exit 0. Block
+// is exit 2 with the reason on stderr.
+func (a *Adapter) RenderResponse(hookType string, decision agent.HookDecision, detail string) agent.HookResponse {
+	jsonHook := hookType == blockingHookType
+	switch decision {
+	case agent.DecisionBlock:
+		r := NewBlockResponse(detail)
+		resp := agent.RenderedResponse{Err: r.Stderr(), Code: r.ExitCode()}
+		if jsonHook {
+			resp.Out = r.JSON()
+		}
+		return resp
+	case agent.DecisionGuidance:
+		r := NewGuidanceResponse(detail)
+		if jsonHook {
+			return agent.RenderedResponse{Out: r.JSON()}
+		}
+		return agent.RenderedResponse{Err: r.Stderr()}
+	default:
+		return agent.RenderedResponse{}
+	}
+}

--- a/agent/openclaw/render_test.go
+++ b/agent/openclaw/render_test.go
@@ -1,0 +1,38 @@
+package openclaw
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderResponse(t *testing.T) {
+	a := New(nil, "", false)
+
+	tests := []struct {
+		name     string
+		hookType string
+		decision agent.HookDecision
+		detail   string
+		wantOut  []byte
+		wantErr  string
+		wantCode int
+	}{
+		{"allow blocking hook", "before_tool_call", agent.DecisionAllow, "", nil, "", 0},
+		{"allow other hook", "after_tool_call", agent.DecisionAllow, "", nil, "", 0},
+		{"block blocking hook", "before_tool_call", agent.DecisionBlock, "reason", NewBlockResponse("reason").JSON(), "reason", 2},
+		{"block other hook", "after_tool_call", agent.DecisionBlock, "reason", nil, "reason", 2},
+		{"guidance blocking hook", "before_tool_call", agent.DecisionGuidance, "advisory", NewGuidanceResponse("advisory").JSON(), "", 0},
+		{"guidance other hook", "after_tool_call", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := a.RenderResponse(tt.hookType, tt.decision, tt.detail)
+			assert.Equal(t, tt.wantOut, resp.Stdout())
+			assert.Equal(t, tt.wantErr, resp.Stderr())
+			assert.Equal(t, tt.wantCode, resp.ExitCode())
+		})
+	}
+}

--- a/agent/opencode/adapter.go
+++ b/agent/opencode/adapter.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	AgentName   = agent.AgentOpenCode
-	DisplayName = agent.DisplayOpenCode
+	DisplayName = "OpenCode"
 )
 
 type Adapter struct {

--- a/agent/opencode/adapter.go
+++ b/agent/opencode/adapter.go
@@ -56,3 +56,31 @@ func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, l
 }
 
 var _ agent.Adapter = (*Adapter)(nil)
+
+// blockingHookType is the one hook with a JSON decision channel.
+const blockingHookType = "tool.execute.before"
+
+// RenderResponse maps a decision to the wire response. The blocking hook
+// carries a JSON decision on stdout. Allow on other hooks emits nothing.
+// Guidance on other hooks routes advisory text to stderr at exit 0. Block
+// is exit 2 with the reason on stderr.
+func (a *Adapter) RenderResponse(hookType string, decision agent.HookDecision, detail string) agent.HookResponse {
+	jsonHook := hookType == blockingHookType
+	switch decision {
+	case agent.DecisionBlock:
+		r := NewBlockResponse(detail)
+		resp := agent.RenderedResponse{Err: r.Stderr(), Code: r.ExitCode()}
+		if jsonHook {
+			resp.Out = r.JSON()
+		}
+		return resp
+	case agent.DecisionGuidance:
+		r := NewGuidanceResponse(detail)
+		if jsonHook {
+			return agent.RenderedResponse{Out: r.JSON()}
+		}
+		return agent.RenderedResponse{Err: r.Stderr()}
+	default:
+		return agent.RenderedResponse{}
+	}
+}

--- a/agent/opencode/render_test.go
+++ b/agent/opencode/render_test.go
@@ -1,0 +1,38 @@
+package opencode
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderResponse(t *testing.T) {
+	a := New(nil, "", false)
+
+	tests := []struct {
+		name     string
+		hookType string
+		decision agent.HookDecision
+		detail   string
+		wantOut  []byte
+		wantErr  string
+		wantCode int
+	}{
+		{"allow blocking hook", "tool.execute.before", agent.DecisionAllow, "", nil, "", 0},
+		{"allow other hook", "tool.execute.after", agent.DecisionAllow, "", nil, "", 0},
+		{"block blocking hook", "tool.execute.before", agent.DecisionBlock, "reason", NewBlockResponse("reason").JSON(), "reason", 2},
+		{"block other hook", "tool.execute.after", agent.DecisionBlock, "reason", nil, "reason", 2},
+		{"guidance blocking hook", "tool.execute.before", agent.DecisionGuidance, "advisory", NewGuidanceResponse("advisory").JSON(), "", 0},
+		{"guidance other hook", "tool.execute.after", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := a.RenderResponse(tt.hookType, tt.decision, tt.detail)
+			assert.Equal(t, tt.wantOut, resp.Stdout())
+			assert.Equal(t, tt.wantErr, resp.Stderr())
+			assert.Equal(t, tt.wantCode, resp.ExitCode())
+		})
+	}
+}

--- a/agent/piagent/adapter.go
+++ b/agent/piagent/adapter.go
@@ -56,3 +56,31 @@ func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, l
 }
 
 var _ agent.Adapter = (*Adapter)(nil)
+
+// blockingHookType is the one hook with a JSON decision channel.
+const blockingHookType = "tool_call"
+
+// RenderResponse maps a decision to the wire response. The blocking hook
+// carries a JSON decision on stdout. Allow on other hooks emits nothing.
+// Guidance on other hooks routes advisory text to stderr at exit 0. Block
+// is exit 2 with the reason on stderr.
+func (a *Adapter) RenderResponse(hookType string, decision agent.HookDecision, detail string) agent.HookResponse {
+	jsonHook := hookType == blockingHookType
+	switch decision {
+	case agent.DecisionBlock:
+		r := NewBlockResponse(detail)
+		resp := agent.RenderedResponse{Err: r.Stderr(), Code: r.ExitCode()}
+		if jsonHook {
+			resp.Out = r.JSON()
+		}
+		return resp
+	case agent.DecisionGuidance:
+		r := NewGuidanceResponse(detail)
+		if jsonHook {
+			return agent.RenderedResponse{Out: r.JSON()}
+		}
+		return agent.RenderedResponse{Err: r.Stderr()}
+	default:
+		return agent.RenderedResponse{}
+	}
+}

--- a/agent/piagent/adapter.go
+++ b/agent/piagent/adapter.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	AgentName   = agent.AgentPiAgent
-	DisplayName = agent.DisplayPiAgent
+	DisplayName = "Pi Agent"
 )
 
 type Adapter struct {

--- a/agent/piagent/render_test.go
+++ b/agent/piagent/render_test.go
@@ -1,0 +1,38 @@
+package piagent
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderResponse(t *testing.T) {
+	a := New(nil, "", false)
+
+	tests := []struct {
+		name     string
+		hookType string
+		decision agent.HookDecision
+		detail   string
+		wantOut  []byte
+		wantErr  string
+		wantCode int
+	}{
+		{"allow blocking hook", "tool_call", agent.DecisionAllow, "", nil, "", 0},
+		{"allow other hook", "session_start", agent.DecisionAllow, "", nil, "", 0},
+		{"block blocking hook", "tool_call", agent.DecisionBlock, "reason", NewBlockResponse("reason").JSON(), "reason", 2},
+		{"block other hook", "session_start", agent.DecisionBlock, "reason", nil, "reason", 2},
+		{"guidance blocking hook", "tool_call", agent.DecisionGuidance, "advisory", NewGuidanceResponse("advisory").JSON(), "", 0},
+		{"guidance other hook", "session_start", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := a.RenderResponse(tt.hookType, tt.decision, tt.detail)
+			assert.Equal(t, tt.wantOut, resp.Stdout())
+			assert.Equal(t, tt.wantErr, resp.Stderr())
+			assert.Equal(t, tt.wantCode, resp.ExitCode())
+		})
+	}
+}

--- a/agent/registry.go
+++ b/agent/registry.go
@@ -75,24 +75,3 @@ func (r *Registry) DetectAll(ctx context.Context) map[string]*DetectionResult {
 	}
 	return results
 }
-
-// SupportedAgents returns the list of supported agent names.
-func SupportedAgents() []string {
-	return []string{
-		"claude-code",
-		"codex",
-		"cursor",
-		"gemini",
-		"opencode",
-		"openclaw",
-		"windsurf",
-		"pi-agent",
-	}
-}
-
-// DefaultRegistry returns a registry with all default adapters registered.
-func DefaultRegistry() *Registry {
-	registry := NewRegistry()
-	// Adapters are registered in their respective packages
-	return registry
-}

--- a/agent/windsurf/adapter.go
+++ b/agent/windsurf/adapter.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	AgentName   = agent.AgentWindsurf
-	DisplayName = agent.DisplayWindsurf
+	DisplayName = "Windsurf"
 )
 
 type Adapter struct {

--- a/agent/windsurf/adapter.go
+++ b/agent/windsurf/adapter.go
@@ -51,6 +51,22 @@ func (a *Adapter) ParseEvent(ctx context.Context, hookType string, rawData []byt
 	return a.parseHookEvent(hookType, rawData)
 }
 
+// RenderResponse maps a decision to the Windsurf wire response. Windsurf has
+// no JSON channel. Block is exit 2 with the reason on stderr. Guidance is
+// exit 0 with advisory text on stderr.
+func (a *Adapter) RenderResponse(hookType string, decision agent.HookDecision, detail string) agent.HookResponse {
+	var r *HookResponse
+	switch decision {
+	case agent.DecisionBlock:
+		r = NewBlockResponse(detail)
+	case agent.DecisionGuidance:
+		r = NewGuidanceResponse(detail)
+	default:
+		r = NewAllowResponse()
+	}
+	return agent.RenderedResponse{Err: r.Stderr(), Code: r.ExitCode()}
+}
+
 func Register(registry *agent.Registry, privacyChecker *events.PrivacyChecker, loggingLevel config.LoggingLevel, contentHash bool) {
 	registry.Register(New(privacyChecker, loggingLevel, contentHash))
 }

--- a/agent/windsurf/render_test.go
+++ b/agent/windsurf/render_test.go
@@ -1,0 +1,37 @@
+package windsurf
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderResponse(t *testing.T) {
+	a := New(nil, "", false)
+
+	tests := []struct {
+		name     string
+		hookType string
+		decision agent.HookDecision
+		detail   string
+		wantOut  []byte
+		wantErr  string
+		wantCode int
+	}{
+		{"allow pre hook", "PreToolUse", agent.DecisionAllow, "", nil, "", 0},
+		{"allow post hook", "PostToolUse", agent.DecisionAllow, "", nil, "", 0},
+		{"block pre hook", "PreToolUse", agent.DecisionBlock, "blocked reason", nil, "blocked reason", 2},
+		{"guidance pre hook", "PreToolUse", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+		{"guidance post hook", "PostToolUse", agent.DecisionGuidance, "advisory", nil, "advisory", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := a.RenderResponse(tt.hookType, tt.decision, tt.detail)
+			assert.Equal(t, tt.wantOut, resp.Stdout())
+			assert.Equal(t, tt.wantErr, resp.Stderr())
+			assert.Equal(t, tt.wantCode, resp.ExitCode())
+		})
+	}
+}

--- a/cli/cat.go
+++ b/cli/cat.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/safedep/dry/log"
+	"github.com/safedep/gryph/agent"
 	"github.com/safedep/gryph/core/events"
 	"github.com/safedep/gryph/tui"
 	"github.com/spf13/cobra"
@@ -56,7 +57,7 @@ and conversation context. Accepts full UUIDs or ID prefixes.`,
 				if err != nil {
 					return err
 				}
-				views = append(views, eventToDetailView(event))
+				views = append(views, eventToDetailView(app.Registry, event))
 			}
 
 			return app.Presenter.RenderEventDetails(views)
@@ -91,7 +92,7 @@ func resolveEvent(ctx context.Context, app *App, idArg string) (*events.Event, e
 	return event, nil
 }
 
-func eventToDetailView(e *events.Event) *tui.EventDetailView {
+func eventToDetailView(reg *agent.Registry, e *events.Event) *tui.EventDetailView {
 	view := &tui.EventDetailView{
 		ID:               e.ID.String(),
 		SessionID:        e.SessionID.String(),
@@ -100,7 +101,7 @@ func eventToDetailView(e *events.Event) *tui.EventDetailView {
 		Timestamp:        e.Timestamp,
 		DurationMs:       e.DurationMs,
 		AgentName:        e.AgentName,
-		AgentDisplayName: getAgentDisplayName(e.AgentName),
+		AgentDisplayName: getAgentDisplayName(reg, e.AgentName),
 		AgentVersion:     e.AgentVersion,
 		WorkingDirectory: e.WorkingDirectory,
 		ActionType:       string(e.ActionType),

--- a/cli/hook.go
+++ b/cli/hook.go
@@ -12,14 +12,6 @@ import (
 	"github.com/safedep/dry/log"
 	"github.com/safedep/gryph/aarm/model"
 	"github.com/safedep/gryph/agent"
-	"github.com/safedep/gryph/agent/claudecode"
-	"github.com/safedep/gryph/agent/codex"
-	"github.com/safedep/gryph/agent/cursor"
-	"github.com/safedep/gryph/agent/gemini"
-	"github.com/safedep/gryph/agent/openclaw"
-	"github.com/safedep/gryph/agent/opencode"
-	"github.com/safedep/gryph/agent/piagent"
-	"github.com/safedep/gryph/agent/windsurf"
 	"github.com/safedep/gryph/config"
 	"github.com/safedep/gryph/core/events"
 	"github.com/safedep/gryph/core/security"
@@ -143,7 +135,7 @@ func runHook(ctx context.Context, app *App, agentName, hookType string, rawData 
 			log.Errorf("failed to update session for blocked event: %v", err)
 		}
 
-		return sendSecurityBlockedResponse(agentName, hookType, securityResult)
+		return sendResponse(adapter, hookType, agent.DecisionBlock, securityResult.BlockReason)
 	}
 
 	event.Sequence = sess.TotalActions + 1
@@ -185,9 +177,9 @@ func runHook(ctx context.Context, app *App, agentName, hookType string, rawData 
 	recordAllowedAarmResult(ctx, app, securityResult, event)
 
 	if securityResult.FinalDecision == security.DecisionGuidance {
-		return sendSecurityGuidanceResponse(agentName, hookType, securityResult)
+		return sendResponse(adapter, hookType, agent.DecisionGuidance, securityResult.AggregatedGuidance())
 	}
-	return sendHookResponse(agentName, hookType)
+	return sendResponse(adapter, hookType, agent.DecisionAllow, "")
 }
 
 // recordAllowedAarmResult fans out the post-hook execution outcome to the
@@ -248,372 +240,27 @@ func logHookError(ctx context.Context, app *App, agentName, hookType string, raw
 	}
 }
 
-// sendHookResponse sends the appropriate response to the agent.
-// Returns nil for success (exit code 0), or an error that triggers non-zero exit.
-func sendHookResponse(agentName, hookType string) error {
-	switch agentName {
-	case agent.AgentClaudeCode:
-		// Claude Code exit codes:
-		//   0 = allow (success)
-		//   2 = block (blocking error, stderr shown to Claude)
-		//   1 = non-blocking error (stderr shown to user in verbose mode)
-		// Block/guidance paths are handled upstream by the security evaluator
-		// (see runHook); this is the allow path.
-		response := claudecode.NewAllowResponse()
-		return handleClaudeCodeResponse(response)
+// sendResponse writes the adapter's rendered response. The stderr text
+// travels on one channel only: inside the exit error for a non-zero exit,
+// where main writes it, or directly for exit zero.
+func sendResponse(a agent.Adapter, hookType string, decision agent.HookDecision, detail string) error {
+	resp := a.RenderResponse(hookType, decision, detail)
 
-	case agent.AgentCursor:
-		// Cursor: JSON response to stdout
-		// Different hooks have different response schemas
-		response := generateCursorResponse(hookType)
-		if _, err := os.Stdout.Write(response); err != nil {
+	if out := resp.Stdout(); len(out) > 0 {
+		if _, err := os.Stdout.Write(out); err != nil {
 			log.Errorf("failed to write to stdout: %v", err)
 		}
-
-		return nil
-
-	case agent.AgentGemini:
-		// Gemini CLI: same exit code semantics as Claude Code (0=allow, 2=block, 1=error)
-		// BeforeTool: JSON response to stdout
-		// Other hooks: empty JSON to stdout
-		if hookType == "BeforeTool" {
-			resp := gemini.NewAllowResponse()
-			if _, err := os.Stdout.Write(resp.JSON()); err != nil {
-				log.Errorf("failed to write to stdout: %v", err)
-			}
-		} else {
-			if _, err := os.Stdout.Write([]byte("{}")); err != nil {
-				log.Errorf("failed to write to stdout: %v", err)
-			}
-		}
-		return nil
-
-	case agent.AgentOpenCode:
-		// OpenCode: exit code semantics (0=allow, 2=block via thrown Error in JS shim)
-		// Only tool.execute.before needs a blocking response
-		if hookType == "tool.execute.before" {
-			resp := opencode.NewAllowResponse()
-			return handleOpenCodeResponse(resp)
-		}
-		return nil
-
-	case agent.AgentOpenClaw:
-		// OpenClaw: exit code semantics (0=allow, 2=block via thrown Error in TS plugin)
-		// Only before_tool_call needs a blocking response
-		if hookType == "before_tool_call" {
-			resp := openclaw.NewAllowResponse()
-			return handleOpenClawResponse(resp)
-		}
-		return nil
-
-	case agent.AgentWindsurf:
-		// Windsurf: exit code semantics (0=allow, 2=block for pre-hooks)
-		// Pre-hooks can block via exit code 2; post-hooks just exit 0
-		return handleWindsurfResponse(windsurf.NewAllowResponse())
-
-	case agent.AgentPiAgent:
-		// Pi Agent: exit code semantics (0=allow, 2=block, 1=error)
-		// tool_call hooks can block via exit code 2
-		if hookType == "tool_call" {
-			resp := piagent.NewAllowResponse()
-			return handlePiAgentResponse(resp)
-		}
-		return nil
-
-	case agent.AgentCodex:
-		// Codex: PreToolUse supports deny via JSON on stdout or exit code 2.
-		// Allow is signaled by exit 0 with no output (Codex does not yet
-		// support the "allow" permissionDecision value).
-		return nil
-
-	default:
-		// Unknown agent, just succeed
-		return nil
 	}
-}
 
-// guidanceResponse is implemented by per-agent guidance response types that
-// expose both a JSON channel and a stderr fallback.
-type guidanceResponse interface {
-	JSON() []byte
-	Stderr() string
-}
-
-// emitGuidanceResponse writes the JSON response when the current hook type
-// supports a JSON advisory channel, otherwise surfaces the advisory text on
-// stderr at exit 0.
-func emitGuidanceResponse(hookType, jsonHookType string, r guidanceResponse) error {
-	if jsonHookType != "" && hookType == jsonHookType {
-		if _, err := os.Stdout.Write(r.JSON()); err != nil {
-			log.Errorf("failed to write to stdout: %v", err)
-		}
-		return nil
+	if code := resp.ExitCode(); code != 0 {
+		return &exitError{code: code, message: resp.Stderr()}
 	}
-	if msg := r.Stderr(); msg != "" {
+
+	if msg := resp.Stderr(); msg != "" {
 		fmt.Fprintln(os.Stderr, msg)
 	}
+
 	return nil
-}
-
-// sendSecurityGuidanceResponse emits advisory guidance for non-blocking decisions.
-func sendSecurityGuidanceResponse(agentName, hookType string, result *security.Result) error {
-	guidance := result.AggregatedGuidance()
-
-	switch agentName {
-	case agent.AgentClaudeCode:
-		return handleClaudeCodeResponse(claudecode.NewGuidanceResponse(guidance))
-
-	case agent.AgentCursor:
-		response := cursor.NewGuidanceResponse(guidance)
-		output := generateCursorDecisionResponse(hookType, response, true)
-		if _, err := os.Stdout.Write(output); err != nil {
-			log.Errorf("failed to write to stdout: %v", err)
-		}
-		// preToolUse JSON carries decision=allow with no reason field, so route advisory text to stderr.
-		if hookType == "preToolUse" && response.Reason != "" {
-			fmt.Fprintln(os.Stderr, response.Reason)
-		}
-		return nil
-
-	case agent.AgentGemini:
-		return emitGuidanceResponse(hookType, "BeforeTool", gemini.NewGuidanceResponse(guidance))
-
-	case agent.AgentOpenCode:
-		return emitGuidanceResponse(hookType, "tool.execute.before", opencode.NewGuidanceResponse(guidance))
-
-	case agent.AgentOpenClaw:
-		return emitGuidanceResponse(hookType, "before_tool_call", openclaw.NewGuidanceResponse(guidance))
-
-	case agent.AgentWindsurf:
-		// Windsurf has no JSON advisory channel, fall through to stderr.
-		response := windsurf.NewGuidanceResponse(guidance)
-		if msg := response.Stderr(); msg != "" {
-			fmt.Fprintln(os.Stderr, msg)
-		}
-		return nil
-
-	case agent.AgentPiAgent:
-		return emitGuidanceResponse(hookType, "tool_call", piagent.NewGuidanceResponse(guidance))
-
-	case agent.AgentCodex:
-		return emitGuidanceResponse(hookType, "PreToolUse", codex.NewGuidanceResponse(guidance))
-
-	default:
-		return sendHookResponse(agentName, hookType)
-	}
-}
-
-// sendSecurityBlockedResponse sends a blocked response based on security evaluation.
-func sendSecurityBlockedResponse(agentName, hookType string, result *security.Result) error {
-	switch agentName {
-	case agent.AgentClaudeCode:
-		response := claudecode.NewBlockResponse(result.BlockReason)
-		return handleClaudeCodeResponse(response)
-
-	case agent.AgentCursor:
-		denyResponse := cursor.NewDenyResponse(result.BlockReason)
-		output := generateCursorDecisionResponse(hookType, denyResponse, false)
-		if _, err := os.Stdout.Write(output); err != nil {
-			log.Errorf("failed to write to stdout: %v", err)
-		}
-
-		return nil
-
-	case agent.AgentGemini:
-		response := gemini.NewBlockResponse(result.BlockReason)
-		if hookType == "BeforeTool" {
-			if _, err := os.Stdout.Write(response.JSON()); err != nil {
-				log.Errorf("failed to write to stdout: %v", err)
-			}
-		}
-		return handleGeminiResponse(response)
-
-	case agent.AgentOpenCode:
-		response := opencode.NewBlockResponse(result.BlockReason)
-		if hookType == "tool.execute.before" {
-			if _, err := os.Stdout.Write(response.JSON()); err != nil {
-				log.Errorf("failed to write to stdout: %v", err)
-			}
-		}
-		return handleOpenCodeResponse(response)
-
-	case agent.AgentOpenClaw:
-		response := openclaw.NewBlockResponse(result.BlockReason)
-		if hookType == "before_tool_call" {
-			if _, err := os.Stdout.Write(response.JSON()); err != nil {
-				log.Errorf("failed to write to stdout: %v", err)
-			}
-		}
-		return handleOpenClawResponse(response)
-
-	case agent.AgentWindsurf:
-		response := windsurf.NewBlockResponse(result.BlockReason)
-		return handleWindsurfResponse(response)
-
-	case agent.AgentPiAgent:
-		response := piagent.NewBlockResponse(result.BlockReason)
-		if hookType == "tool_call" {
-			if _, err := os.Stdout.Write(response.JSON()); err != nil {
-				log.Errorf("failed to write to stdout: %v", err)
-			}
-		}
-		return handlePiAgentResponse(response)
-
-	case agent.AgentCodex:
-		response := codex.NewBlockResponse(result.BlockReason)
-		if hookType == "PreToolUse" {
-			if _, err := os.Stdout.Write(response.JSON()); err != nil {
-				log.Errorf("failed to write to stdout: %v", err)
-			}
-		}
-		return handleCodexResponse(response)
-
-	default:
-		return nil
-	}
-}
-
-// generateCursorDecisionResponse builds the JSON response for a Cursor hook
-// type carrying an explicit block (cont=false) or allow-with-advisory
-// (cont=true) decision.
-func generateCursorDecisionResponse(hookType string, response *cursor.HookResponse, cont bool) []byte {
-	switch hookType {
-	case "preToolUse":
-		return cursor.GeneratePreToolUseResponse(response)
-
-	case "beforeShellExecution", "beforeMCPExecution", "beforeReadFile", "beforeTabFileRead":
-		return cursor.GeneratePermissionResponse(response)
-
-	case "beforeSubmitPrompt", "sessionStart":
-		return cursor.GenerateContinueResponse(cont, response.Reason)
-
-	default:
-		return []byte("{}")
-	}
-}
-
-func generateCursorResponse(hookType string) []byte {
-	allowResponse := cursor.NewAllowResponse()
-
-	switch hookType {
-	case "preToolUse":
-		return cursor.GeneratePreToolUseResponse(allowResponse)
-
-	case "beforeShellExecution", "beforeMCPExecution", "beforeReadFile", "beforeTabFileRead":
-		return cursor.GeneratePermissionResponse(allowResponse)
-
-	case "beforeSubmitPrompt", "sessionStart":
-		return cursor.GenerateContinueResponse(true, "")
-
-	case "stop", "subagentStop":
-		return cursor.GenerateStopResponse("")
-
-	case "postToolUse", "postToolUseFailure", "afterFileEdit", "afterTabFileEdit",
-		"afterShellExecution", "afterMCPExecution", "afterAgentThought",
-		"afterAgentResponse", "sessionEnd", "subagentStart", "preCompact":
-		return []byte("{}")
-
-	default:
-		return []byte("{}")
-	}
-}
-
-// handleOpenClawResponse processes an OpenClaw hook response.
-func handleOpenClawResponse(response *openclaw.HookResponse) error {
-	switch response.Decision {
-	case openclaw.HookBlock:
-		return &exitError{code: 2, message: response.Message}
-	case openclaw.HookError:
-		return &exitError{code: 1, message: response.Message}
-	default:
-		return nil
-	}
-}
-
-// handleWindsurfResponse processes a Windsurf hook response.
-func handleWindsurfResponse(response *windsurf.HookResponse) error {
-	switch response.Decision {
-	case windsurf.HookBlock:
-		return &exitError{code: 2, message: response.Message}
-	case windsurf.HookError:
-		return &exitError{code: 1, message: response.Message}
-	default:
-		return nil
-	}
-}
-
-// handleOpenCodeResponse processes an OpenCode hook response.
-func handleOpenCodeResponse(response *opencode.HookResponse) error {
-	switch response.Decision {
-	case opencode.HookBlock:
-		return &exitError{code: 2, message: response.Message}
-	case opencode.HookError:
-		return &exitError{code: 1, message: response.Message}
-	default:
-		return nil
-	}
-}
-
-// handleGeminiResponse processes a Gemini CLI hook response.
-func handleGeminiResponse(response *gemini.HookResponse) error {
-	switch response.Decision {
-	case gemini.HookBlock:
-		return &exitError{code: 2, message: response.Message}
-	case gemini.HookError:
-		return &exitError{code: 1, message: response.Message}
-	default:
-		return nil
-	}
-}
-
-// handlePiAgentResponse processes a Pi Agent hook response.
-func handlePiAgentResponse(response *piagent.HookResponse) error {
-	switch response.Decision {
-	case piagent.HookBlock:
-		return &exitError{code: 2, message: response.Message}
-	case piagent.HookError:
-		return &exitError{code: 1, message: response.Message}
-	default:
-		return nil
-	}
-}
-
-// handleCodexResponse processes a Codex hook response.
-func handleCodexResponse(response *codex.HookResponse) error {
-	switch response.Decision {
-	case codex.HookBlock:
-		return &exitError{code: 2, message: response.Message}
-	case codex.HookError:
-		return &exitError{code: 1, message: response.Message}
-	default:
-		return nil
-	}
-}
-
-// handleClaudeCodeResponse processes a Claude Code hook response.
-// Returns an exitError with the appropriate code and message for non-allow decisions.
-func handleClaudeCodeResponse(response *claudecode.HookResponse) error {
-	switch response.Decision {
-	case claudecode.HookBlock:
-		// Exit code 2: blocking error, message shown to Claude
-		return &exitError{code: 2, message: response.Message}
-
-	case claudecode.HookError:
-		// Exit code 1: non-blocking error, message shown to user in verbose mode
-		return &exitError{code: 1, message: response.Message}
-
-	case claudecode.HookGuidance:
-		// Exit code 0 (allow), but aggregated guidance is written to stderr
-		// for the user. Matches the evaluator's three-valued decision model.
-		if response.Message != "" {
-			fmt.Fprintln(os.Stderr, response.Message)
-		}
-		return nil
-
-	default:
-		// Exit code 0: allow
-		return nil
-	}
 }
 
 // isExitError returns true if the error is an intentional exit code signal

--- a/cli/logs.go
+++ b/cli/logs.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/google/uuid"
 	"github.com/safedep/dry/log"
+	"github.com/safedep/gryph/agent"
 	"github.com/safedep/gryph/core/events"
 	"github.com/safedep/gryph/tui"
 	"github.com/safedep/gryph/tui/component/livelog"
@@ -124,10 +125,14 @@ func runLiveLogs(app *App, p logParams) error {
 		sinceTime = time.Now().UTC().Add(-1 * time.Hour)
 	}
 
+	agentNames := app.Registry.List()
+	slices.Sort(agentNames)
+
 	opts := livelog.Options{
 		Store:        app.Store,
 		PollInterval: p.interval,
 		AgentFilter:  p.agent,
+		AgentNames:   agentNames,
 		InitialLimit: p.limit,
 		Since:        sinceTime,
 	}
@@ -220,7 +225,7 @@ func runListLogs(ctx context.Context, app *App, p logParams) error {
 
 	eventViews := make([]*tui.EventView, len(evts))
 	for i, e := range evts {
-		eventViews[i] = eventToView(e)
+		eventViews[i] = eventToView(app.Registry, e)
 	}
 
 	return app.Presenter.RenderEvents(eventViews)
@@ -246,7 +251,7 @@ func runFollowLogs(ctx context.Context, app *App, p logParams) error {
 		slices.Reverse(evts)
 		eventViews := make([]*tui.EventView, len(evts))
 		for i, e := range evts {
-			eventViews[i] = eventToView(e)
+			eventViews[i] = eventToView(app.Registry, e)
 		}
 		if err := app.Presenter.RenderEvents(eventViews); err != nil {
 			return err
@@ -283,7 +288,7 @@ func runFollowLogs(ctx context.Context, app *App, p logParams) error {
 			if len(newEvts) > 0 {
 				eventViews := make([]*tui.EventView, len(newEvts))
 				for i, e := range newEvts {
-					eventViews[i] = eventToView(e)
+					eventViews[i] = eventToView(app.Registry, e)
 				}
 				if err := app.Presenter.RenderEvents(eventViews); err != nil {
 					return err
@@ -343,7 +348,7 @@ func parseDuration(s string) (time.Time, error) {
 }
 
 // eventToView converts an event to a view model.
-func eventToView(e *events.Event) *tui.EventView {
+func eventToView(reg *agent.Registry, e *events.Event) *tui.EventView {
 	view := &tui.EventView{
 		ID:               e.ID.String(),
 		ShortID:          tui.FormatShortID(e.ID.String()),
@@ -352,7 +357,7 @@ func eventToView(e *events.Event) *tui.EventView {
 		Sequence:         e.Sequence,
 		Timestamp:        e.Timestamp,
 		AgentName:        e.AgentName,
-		AgentDisplayName: getAgentDisplayName(e.AgentName),
+		AgentDisplayName: getAgentDisplayName(reg, e.AgentName),
 		ActionType:       string(e.ActionType),
 		ActionDisplay:    e.ActionType.DisplayName(),
 		ToolName:         e.ToolName,

--- a/cli/query.go
+++ b/cli/query.go
@@ -181,7 +181,7 @@ through the audit history.`,
 			// Convert to view models
 			eventViews := make([]*tui.EventView, len(evts))
 			for i, e := range evts {
-				eventViews[i] = eventToView(e)
+				eventViews[i] = eventToView(app.Registry, e)
 			}
 
 			return app.Presenter.RenderEvents(eventViews)

--- a/cli/session.go
+++ b/cli/session.go
@@ -86,10 +86,10 @@ chronological order with full metadata.`,
 			}
 
 			// Convert to view models
-			sessionView := sessionToView(session)
+			sessionView := sessionToView(app.Registry, session)
 			eventViews := make([]*tui.EventView, len(evts))
 			for i, e := range evts {
-				eventViews[i] = eventToView(e)
+				eventViews[i] = eventToView(app.Registry, e)
 			}
 
 			return app.Presenter.RenderSession(sessionView, eventViews)

--- a/cli/sessions.go
+++ b/cli/sessions.go
@@ -80,7 +80,7 @@ Shows all recorded agent sessions with summary statistics.`,
 			// Convert to view models
 			sessionViews := make([]*tui.SessionView, len(sessions))
 			for i, s := range sessions {
-				sessionViews[i] = sessionToView(s)
+				sessionViews[i] = sessionToView(app.Registry, s)
 			}
 
 			return app.Presenter.RenderSessions(sessionViews)
@@ -96,12 +96,12 @@ Shows all recorded agent sessions with summary statistics.`,
 }
 
 // sessionToView converts a session to a view model.
-func sessionToView(s *session.Session) *tui.SessionView {
+func sessionToView(reg *agent.Registry, s *session.Session) *tui.SessionView {
 	view := &tui.SessionView{
 		ID:               s.ID.String(),
 		ShortID:          tui.FormatShortID(s.ID.String()),
 		AgentName:        s.AgentName,
-		AgentDisplayName: getAgentDisplayName(s.AgentName),
+		AgentDisplayName: getAgentDisplayName(reg, s.AgentName),
 		AgentVersion:     s.AgentVersion,
 		StartedAt:        s.StartedAt,
 		EndedAt:          s.EndedAt,
@@ -137,7 +137,11 @@ func sessionToView(s *session.Session) *tui.SessionView {
 	return view
 }
 
-// getAgentDisplayName returns the display name for an agent.
-func getAgentDisplayName(name string) string {
-	return agent.AgentDisplayName(name)
+// getAgentDisplayName returns the display name from the registered adapter.
+// An unknown agent renders as its raw name.
+func getAgentDisplayName(reg *agent.Registry, name string) string {
+	if a, ok := reg.Get(name); ok {
+		return a.DisplayName()
+	}
+	return name
 }

--- a/cli/sessions_test.go
+++ b/cli/sessions_test.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/safedep/gryph/agent"
+	"github.com/safedep/gryph/agent/claudecode"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAgentDisplayName(t *testing.T) {
+	reg := agent.NewRegistry()
+	reg.Register(claudecode.New(nil, "", false))
+
+	assert.Equal(t, "Claude Code", getAgentDisplayName(reg, "claude-code"))
+	assert.Equal(t, "future-agent", getAgentDisplayName(reg, "future-agent"))
+}

--- a/config/config.go
+++ b/config/config.go
@@ -13,18 +13,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Agent names as constants. Must be in sync with agent/adapter.go.
-// We cannot depend on agent/adapter.go because it would create a circular dependency.
 const (
-	agentNameClaudeCode = "claude-code"
-	agentNameCursor     = "cursor"
-	agentNameGemini     = "gemini"
-	agentNameOpenCode   = "opencode"
-	agentNameOpenClaw   = "openclaw"
-	agentNameWindsurf   = "windsurf"
-	agentNamePiAgent    = "pi-agent"
-	agentNameCodex      = "codex"
-
 	streamTargetTypeStdout = "stdout"
 	streamTargetTypeNop    = "nop"
 )
@@ -240,17 +229,9 @@ type AgentConfig struct {
 	LoggingLevel LoggingLevel `mapstructure:"logging_level,omitempty"`
 }
 
-// AgentsConfig holds per-agent settings.
-type AgentsConfig struct {
-	ClaudeCode AgentConfig `mapstructure:"claude-code"`
-	Cursor     AgentConfig `mapstructure:"cursor"`
-	Gemini     AgentConfig `mapstructure:"gemini"`
-	OpenCode   AgentConfig `mapstructure:"opencode"`
-	OpenClaw   AgentConfig `mapstructure:"openclaw"`
-	Windsurf   AgentConfig `mapstructure:"windsurf"`
-	PiAgent    AgentConfig `mapstructure:"pi-agent"`
-	Codex      AgentConfig `mapstructure:"codex"`
-}
+// AgentsConfig holds per-agent settings keyed by agent name. The keys match
+// the adapter names from agent registration, e.g. "claude-code".
+type AgentsConfig map[string]AgentConfig
 
 // DisplayConfig holds display-related settings.
 type DisplayConfig struct {
@@ -395,11 +376,49 @@ func bindStructEnvKeys(v *viper.Viper, t reflect.Type, prefix string) error {
 			}
 			continue
 		}
+		// A map field has no static keys to walk. Bind the value-struct
+		// leaves under each key viper already knows from defaults or the
+		// config file, so env overrides keep working for those entries.
+		if fieldType.Kind() == reflect.Map {
+			elem := fieldType.Elem()
+			if elem.Kind() == reflect.Pointer {
+				elem = elem.Elem()
+			}
+			if elem.Kind() != reflect.Struct {
+				continue
+			}
+			for _, name := range knownMapKeys(v, key) {
+				if err := bindStructEnvKeys(v, elem, key+"."+name); err != nil {
+					return err
+				}
+			}
+			continue
+		}
 		if err := v.BindEnv(key); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// knownMapKeys returns the child key names viper knows under prefix, from
+// defaults and the config file.
+func knownMapKeys(v *viper.Viper, prefix string) []string {
+	seen := make(map[string]bool)
+	var keys []string
+	p := prefix + "."
+	for _, k := range v.AllKeys() {
+		rest, ok := strings.CutPrefix(k, p)
+		if !ok {
+			continue
+		}
+		name, _, _ := strings.Cut(rest, ".")
+		if !seen[name] {
+			seen[name] = true
+			keys = append(keys, name)
+		}
+	}
+	return keys
 }
 
 // Default returns a Config with all default values.
@@ -519,64 +538,17 @@ func (c *Config) ShouldUseColors() bool {
 // GetAgentLoggingLevel returns the logging level for a specific agent.
 // Falls back to global level if not set.
 func (c *Config) GetAgentLoggingLevel(agentName string) LoggingLevel {
-	switch agentName {
-	case agentNameClaudeCode:
-		if c.Agents.ClaudeCode.LoggingLevel != "" {
-			return c.Agents.ClaudeCode.LoggingLevel
-		}
-	case agentNameCursor:
-		if c.Agents.Cursor.LoggingLevel != "" {
-			return c.Agents.Cursor.LoggingLevel
-		}
-	case agentNameGemini:
-		if c.Agents.Gemini.LoggingLevel != "" {
-			return c.Agents.Gemini.LoggingLevel
-		}
-	case agentNameOpenCode:
-		if c.Agents.OpenCode.LoggingLevel != "" {
-			return c.Agents.OpenCode.LoggingLevel
-		}
-	case agentNameOpenClaw:
-		if c.Agents.OpenClaw.LoggingLevel != "" {
-			return c.Agents.OpenClaw.LoggingLevel
-		}
-	case agentNameWindsurf:
-		if c.Agents.Windsurf.LoggingLevel != "" {
-			return c.Agents.Windsurf.LoggingLevel
-		}
-	case agentNamePiAgent:
-		if c.Agents.PiAgent.LoggingLevel != "" {
-			return c.Agents.PiAgent.LoggingLevel
-		}
-	case agentNameCodex:
-		if c.Agents.Codex.LoggingLevel != "" {
-			return c.Agents.Codex.LoggingLevel
-		}
+	if ac, ok := c.Agents[agentName]; ok && ac.LoggingLevel != "" {
+		return ac.LoggingLevel
 	}
-
 	return c.Logging.Level
 }
 
 // IsAgentEnabled returns true if the given agent is enabled.
+// An agent without a config entry is enabled.
 func (c *Config) IsAgentEnabled(agentName string) bool {
-	switch agentName {
-	case agentNameClaudeCode:
-		return c.Agents.ClaudeCode.Enabled
-	case agentNameCursor:
-		return c.Agents.Cursor.Enabled
-	case agentNameGemini:
-		return c.Agents.Gemini.Enabled
-	case agentNameOpenCode:
-		return c.Agents.OpenCode.Enabled
-	case agentNameOpenClaw:
-		return c.Agents.OpenClaw.Enabled
-	case agentNameWindsurf:
-		return c.Agents.Windsurf.Enabled
-	case agentNamePiAgent:
-		return c.Agents.PiAgent.Enabled
-	case agentNameCodex:
-		return c.Agents.Codex.Enabled
-	default:
-		return true
+	if ac, ok := c.Agents[agentName]; ok {
+		return ac.Enabled
 	}
+	return true
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,10 +34,10 @@ func TestDefault(t *testing.T) {
 	assert.False(t, cfg.Filters.Enabled)
 
 	// Verify agent defaults
-	assert.True(t, cfg.Agents.ClaudeCode.Enabled)
-	assert.True(t, cfg.Agents.Cursor.Enabled)
-	assert.Empty(t, cfg.Agents.ClaudeCode.LoggingLevel)
-	assert.Empty(t, cfg.Agents.Cursor.LoggingLevel)
+	assert.True(t, cfg.Agents["claude-code"].Enabled)
+	assert.True(t, cfg.Agents["cursor"].Enabled)
+	assert.Empty(t, cfg.Agents["claude-code"].LoggingLevel)
+	assert.Empty(t, cfg.Agents["cursor"].LoggingLevel)
 
 	// Verify display defaults
 	assert.Equal(t, ColorAuto, cfg.Display.Colors)
@@ -108,9 +108,9 @@ policy:
 	assert.Equal(t, 30, cfg.Storage.RetentionDays)
 	assert.False(t, cfg.Logging.ContentHash)
 	assert.Equal(t, []string{"**/.env"}, cfg.Privacy.SensitivePaths)
-	assert.False(t, cfg.Agents.ClaudeCode.Enabled)
-	assert.Equal(t, LoggingFull, cfg.Agents.ClaudeCode.LoggingLevel)
-	assert.True(t, cfg.Agents.Cursor.Enabled)
+	assert.False(t, cfg.Agents["claude-code"].Enabled)
+	assert.Equal(t, LoggingFull, cfg.Agents["claude-code"].LoggingLevel)
+	assert.True(t, cfg.Agents["cursor"].Enabled)
 	assert.Equal(t, ColorAlways, cfg.Display.Colors)
 	assert.Equal(t, TimezoneUTC, cfg.Display.Timezone)
 	assert.True(t, cfg.Policy.Enabled)
@@ -281,6 +281,31 @@ agents:
 	assert.Contains(t, err.Error(), "invalid agents.claude-code.logging_level")
 }
 
+func TestLoad_AgentWithoutDefaultBindsIntoMap(t *testing.T) {
+	configContent := `
+agents:
+  future-agent:
+    enabled: false
+    logging_level: minimal
+`
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	err := os.WriteFile(configFile, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	cfg, err := Load(configFile)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	ac, ok := cfg.Agents["future-agent"]
+	require.True(t, ok)
+	assert.False(t, ac.Enabled)
+	assert.Equal(t, LoggingMinimal, ac.LoggingLevel)
+	assert.False(t, cfg.IsAgentEnabled("future-agent"))
+	assert.Equal(t, LoggingMinimal, cfg.GetAgentLoggingLevel("future-agent"))
+}
+
 func TestLoad_NonExistentFile_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	nonExistentFile := filepath.Join(tmpDir, "nonexistent.yaml")
@@ -353,8 +378,8 @@ func TestConfig_GetAgentLoggingLevel_Default(t *testing.T) {
 func TestConfig_GetAgentLoggingLevel_PerAgent(t *testing.T) {
 	cfg := Default()
 	cfg.Logging.Level = LoggingMinimal
-	cfg.Agents.ClaudeCode.LoggingLevel = LoggingFull
-	cfg.Agents.Cursor.LoggingLevel = LoggingStandard
+	cfg.Agents["claude-code"] = AgentConfig{Enabled: true, LoggingLevel: LoggingFull}
+	cfg.Agents["cursor"] = AgentConfig{Enabled: true, LoggingLevel: LoggingStandard}
 
 	assert.Equal(t, LoggingFull, cfg.GetAgentLoggingLevel("claude-code"))
 	assert.Equal(t, LoggingStandard, cfg.GetAgentLoggingLevel("cursor"))
@@ -370,8 +395,8 @@ func TestConfig_IsAgentEnabled_Defaults(t *testing.T) {
 
 func TestConfig_IsAgentEnabled_Disabled(t *testing.T) {
 	cfg := Default()
-	cfg.Agents.ClaudeCode.Enabled = false
-	cfg.Agents.Cursor.Enabled = false
+	cfg.Agents["claude-code"] = AgentConfig{Enabled: false}
+	cfg.Agents["cursor"] = AgentConfig{Enabled: false}
 
 	assert.False(t, cfg.IsAgentEnabled("claude-code"))
 	assert.False(t, cfg.IsAgentEnabled("cursor"))
@@ -508,7 +533,7 @@ logging:
 	// Default values
 	assert.Equal(t, 1000, cfg.Logging.StdoutMaxChars)
 	assert.Equal(t, 90, cfg.Storage.RetentionDays)
-	assert.True(t, cfg.Agents.ClaudeCode.Enabled)
+	assert.True(t, cfg.Agents["claude-code"].Enabled)
 	assert.Equal(t, ColorAuto, cfg.Display.Colors)
 }
 
@@ -586,5 +611,5 @@ storage:
 
 	assert.Equal(t, LoggingMinimal, cfg.Logging.Level)
 	assert.Equal(t, 7, cfg.Storage.RetentionDays)
-	assert.Equal(t, LoggingMinimal, cfg.Agents.Cursor.LoggingLevel)
+	assert.Equal(t, LoggingMinimal, cfg.Agents["cursor"].LoggingLevel)
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -58,29 +58,10 @@ func validate(cfg *Config) error {
 	}
 
 	// Validate agent logging levels if set
-	if cfg.Agents.ClaudeCode.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.ClaudeCode.LoggingLevel) {
-		return fmt.Errorf("invalid agents.claude-code.logging_level: %s", cfg.Agents.ClaudeCode.LoggingLevel)
-	}
-	if cfg.Agents.Cursor.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.Cursor.LoggingLevel) {
-		return fmt.Errorf("invalid agents.cursor.logging_level: %s", cfg.Agents.Cursor.LoggingLevel)
-	}
-	if cfg.Agents.Gemini.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.Gemini.LoggingLevel) {
-		return fmt.Errorf("invalid agents.gemini.logging_level: %s", cfg.Agents.Gemini.LoggingLevel)
-	}
-	if cfg.Agents.OpenCode.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.OpenCode.LoggingLevel) {
-		return fmt.Errorf("invalid agents.opencode.logging_level: %s", cfg.Agents.OpenCode.LoggingLevel)
-	}
-	if cfg.Agents.OpenClaw.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.OpenClaw.LoggingLevel) {
-		return fmt.Errorf("invalid agents.openclaw.logging_level: %s", cfg.Agents.OpenClaw.LoggingLevel)
-	}
-	if cfg.Agents.Windsurf.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.Windsurf.LoggingLevel) {
-		return fmt.Errorf("invalid agents.windsurf.logging_level: %s", cfg.Agents.Windsurf.LoggingLevel)
-	}
-	if cfg.Agents.PiAgent.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.PiAgent.LoggingLevel) {
-		return fmt.Errorf("invalid agents.pi-agent.logging_level: %s", cfg.Agents.PiAgent.LoggingLevel)
-	}
-	if cfg.Agents.Codex.LoggingLevel != "" && !isValidLoggingLevel(cfg.Agents.Codex.LoggingLevel) {
-		return fmt.Errorf("invalid agents.codex.logging_level: %s", cfg.Agents.Codex.LoggingLevel)
+	for name, ac := range cfg.Agents {
+		if ac.LoggingLevel != "" && !isValidLoggingLevel(ac.LoggingLevel) {
+			return fmt.Errorf("invalid agents.%s.logging_level: %s", name, ac.LoggingLevel)
+		}
 	}
 
 	return nil

--- a/docs/agent-adapter.md
+++ b/docs/agent-adapter.md
@@ -15,8 +15,13 @@ type Adapter interface {
     Uninstall(ctx context.Context, opts UninstallOptions) (*UninstallResult, error)
     Status(ctx context.Context) (*HookStatus, error)
     ParseEvent(ctx context.Context, hookType string, rawData []byte) (*events.Event, error)
+    RenderResponse(hookType string, decision HookDecision, detail string) HookResponse
 }
 ```
+
+The registry (`agent/registry.go`) is the single source of truth for which
+agents exist. Per-agent knowledge lives inside the adapter package. The CLI,
+config, and tui layers do not enumerate agents.
 
 ## Step-by-step
 
@@ -93,27 +98,44 @@ This is where hook stdin JSON gets converted to `events.Event` objects.
 - **Block** - `NewBlockResponse(reason)`. The engine blocks the action.
 - **Guidance** - `NewGuidanceResponse(guidance)`. The engine sends an advisory but does not block.
 
-The guidance response must satisfy the `guidanceResponse` interface in `cli/hook.go` (`JSON() []byte` and `Stderr() string`). Use the exit code semantics your agent expects. The common pattern is exit 0 for allow and exit 2 for block.
-
 See `agent/gemini/parser.go` for a complete example.
+
+**RenderResponse** - Implement `RenderResponse` on the adapter. It maps a
+`agent.HookDecision` (allow, block, guidance) and a hook type to an
+`agent.HookResponse` value: the stdout bytes, the stderr text, and the exit
+code. The adapter owns the per-hook-type wire knowledge. The CLI performs
+the IO through one generic `sendResponse` routine in `cli/hook.go`. Return
+an `agent.RenderedResponse` built from your response constructors. The
+common pattern is exit 0 for allow and guidance, and exit 2 with the reason
+on stderr for block. See `agent/gemini/adapter.go` for the JSON-channel
+pattern and `agent/cursor/adapter.go` for a per-hook schema switch.
+
+Add a `render_test.go` table test over the hook type and decision matrix.
+Assert `Stdout()`, `Stderr()`, and `ExitCode()`.
 
 ### 6. Register the adapter
 
-Modify these files to wire everything up:
+Required edits outside the adapter package:
 
 | File | Change |
 |---|---|
-| `agent/adapter.go` | Add `AgentYourAgent` and `DisplayYourAgent` constants, add case to `AgentDisplayName()` |
-| `agent/registry.go` | Add agent name to `SupportedAgents()` slice |
-| `config/config.go` | Add agent name constant, `AgentConfig` field in `AgentsConfig`, cases in `GetAgentLoggingLevel()` and `IsAgentEnabled()` |
+| `agent/adapter.go` | Add the `AgentYourAgent` name constant |
+| `cli/root.go` | Import the package and call `Register()` |
 | `config/defaults.go` | Add `v.SetDefault("agents.youragent.enabled", true)` |
-| `config/validate.go` | Add logging level validation |
-| `cli/root.go` | Import package and call `Register()` |
-| `cli/hook.go` | Add cases in `sendHookResponse()`, `sendSecurityBlockedResponse()`, and `sendSecurityGuidanceResponse()`, add `handleYourAgentResponse()` |
-| `tui/component/livelog/model.go` | Add agent name to `agentCycle` slice |
-| `tui/component/livelog/styles.go` | Add agent badge color case in `agentBadge()` |
 
-An adapter can be fully wired but not active. To keep an adapter out of the registry, comment out its `Register()` call in `cli/root.go`. See the `openclaw` adapter for this pattern. All other wiring stays in place.
+Optional:
+
+| File | Change |
+|---|---|
+| `tui/component/livelog/styles.go` | Add an entry to `agentBadgeColors`. Without it, the agent badge renders in the default dim color |
+
+Everything else derives from registration. The config map accepts any agent
+key. The display name comes from the adapter through the registry. The
+livelog filter cycle comes from `Registry.List()`.
+
+An adapter can exist in code but stay out of the registry. To deactivate an
+adapter, comment out its `Register()` call in `cli/root.go`. See the
+`openclaw` adapter for this pattern.
 
 ### 7. Write tests
 

--- a/tui/component/livelog/model.go
+++ b/tui/component/livelog/model.go
@@ -8,8 +8,6 @@ import (
 	"github.com/safedep/gryph/core/events"
 )
 
-var agentCycle = []string{"", "claude-code", "codex", "cursor", "gemini", "opencode", "openclaw", "windsurf", "pi-agent"}
-
 type Model struct {
 	opts   Options
 	width  int
@@ -176,10 +174,11 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) cycleAgentFilter() {
+	cycle := m.opts.agentCycle()
 	current := m.agentFilter
-	for i, a := range agentCycle {
+	for i, a := range cycle {
 		if a == current {
-			m.agentFilter = agentCycle[(i+1)%len(agentCycle)]
+			m.agentFilter = cycle[(i+1)%len(cycle)]
 			return
 		}
 	}

--- a/tui/component/livelog/model_test.go
+++ b/tui/component/livelog/model_test.go
@@ -1,0 +1,43 @@
+package livelog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCycleAgentFilter(t *testing.T) {
+	m := New(Options{AgentNames: []string{"claude-code", "cursor"}})
+	assert.Equal(t, "", m.agentFilter)
+
+	m.cycleAgentFilter()
+	assert.Equal(t, "claude-code", m.agentFilter)
+
+	m.cycleAgentFilter()
+	assert.Equal(t, "cursor", m.agentFilter)
+
+	m.cycleAgentFilter()
+	assert.Equal(t, "", m.agentFilter)
+}
+
+func TestCycleAgentFilter_UnknownFilterResets(t *testing.T) {
+	m := New(Options{AgentNames: []string{"claude-code"}, AgentFilter: "gone-agent"})
+
+	m.cycleAgentFilter()
+	assert.Equal(t, "", m.agentFilter)
+}
+
+func TestCycleAgentFilter_EmptyNameList(t *testing.T) {
+	m := New(Options{})
+
+	m.cycleAgentFilter()
+	assert.Equal(t, "", m.agentFilter)
+}
+
+func TestAgentBadge_UnknownAgentRendersRawName(t *testing.T) {
+	assert.Contains(t, agentBadge("future-agent"), "future-agent")
+}
+
+func TestAgentBadge_KnownAgentRendersName(t *testing.T) {
+	assert.Contains(t, agentBadge("claude-code"), "claude-code")
+}

--- a/tui/component/livelog/options.go
+++ b/tui/component/livelog/options.go
@@ -10,8 +10,17 @@ type Options struct {
 	Store        storage.Store
 	PollInterval time.Duration
 	AgentFilter  string
+	// AgentNames is the list of agent names the filter key cycles through.
+	// The caller sources it from the adapter registry.
+	AgentNames   []string
 	InitialLimit int
 	Since        time.Time
+}
+
+// agentCycle returns the filter cycle: the empty all filter first, then the
+// configured agent names.
+func (o Options) agentCycle() []string {
+	return append([]string{""}, o.AgentNames...)
 }
 
 func (o Options) pollInterval() time.Duration {

--- a/tui/component/livelog/styles.go
+++ b/tui/component/livelog/styles.go
@@ -114,25 +114,23 @@ func statusStyleFor(status events.ResultStatus) lipgloss.Style {
 	}
 }
 
+// agentBadgeColors maps an agent name to its badge color. Color is a
+// presentation concern, so the map stays in the tui layer. An agent
+// without an entry renders in the default dim color.
+var agentBadgeColors = map[string]lipgloss.Color{
+	"claude-code": colorOrange,
+	"codex":       colorYellow,
+	"cursor":      colorViolet,
+	"gemini":      colorBlue,
+	"opencode":    colorTeal,
+	"openclaw":    colorPink,
+	"windsurf":    colorGreen,
+	"pi-agent":    colorIndigo,
+}
+
 func agentBadge(agentName string) string {
-	switch agentName {
-	case "claude-code":
-		return lipgloss.NewStyle().Foreground(colorOrange).Bold(true).Render("claude-code")
-	case "codex":
-		return lipgloss.NewStyle().Foreground(colorYellow).Bold(true).Render("codex")
-	case "cursor":
-		return lipgloss.NewStyle().Foreground(colorViolet).Bold(true).Render("cursor")
-	case "gemini":
-		return lipgloss.NewStyle().Foreground(colorBlue).Bold(true).Render("gemini")
-	case "opencode":
-		return lipgloss.NewStyle().Foreground(colorTeal).Bold(true).Render("opencode")
-	case "openclaw":
-		return lipgloss.NewStyle().Foreground(colorPink).Bold(true).Render("openclaw")
-	case "windsurf":
-		return lipgloss.NewStyle().Foreground(colorGreen).Bold(true).Render("windsurf")
-	case "pi-agent":
-		return lipgloss.NewStyle().Foreground(colorIndigo).Bold(true).Render("pi-agent")
-	default:
-		return lipgloss.NewStyle().Foreground(colorDim).Render(agentName)
+	if color, ok := agentBadgeColors[agentName]; ok {
+		return lipgloss.NewStyle().Foreground(color).Bold(true).Render(agentName)
 	}
+	return lipgloss.NewStyle().Foreground(colorDim).Render(agentName)
 }


### PR DESCRIPTION
## Summary

Adding an agent adapter took edits to 13 or more files. The set of agents and per-agent behavior lived in five places that did not derive from the registry. This change makes the registry the single source of truth and moves per-agent behavior onto the adapter. Adding an agent now takes three required edits: the adapter package, one `Register()` call in `cli/root.go`, and one defaults entry in `config/defaults.go`. A badge color entry in the tui is optional.

The work lands in three commits, one per phase. Each phase compiles and passes tests on its own.

### Phase 1: config as a map

- `AgentsConfig` becomes `map[string]AgentConfig`. The config file keys do not change.
- `GetAgentLoggingLevel` and `IsAgentEnabled` become map lookups. The validator iterates the map.
- `bindStructEnvKeys` binds the map value struct under each key viper knows from defaults or the file. Env overrides such as `GRYPH_AGENTS_CURSOR_LOGGING_LEVEL` keep working, and the existing env test pins this.
- The duplicated agent name constants in `config/config.go` are gone with the circular-dependency workaround they served.

### Phase 2: registry-derived enumeration

- `SupportedAgents()` and `DefaultRegistry()` are deleted. Both had no callers.
- `AgentDisplayName()` and the `Display*` constants are deleted. Each adapter package holds its own display name. The CLI resolves it through the registry and falls back to the raw name for an unknown agent.
- The livelog filter cycle comes from `Options.AgentNames`, sourced from `Registry.List()` sorted. The badge color switch becomes a map with a dim default.
- Behavior note: the unregistered `openclaw` adapter leaves the filter cycle. Its historical events stay visible under the all filter.

### Phase 3: response rendering on the adapter

- The `agent` package gains `HookDecision` (allow, block, guidance), the `HookResponse` interface (`Stdout`, `Stderr`, `ExitCode`), and the `RenderedResponse` value.
- Each adapter implements `RenderResponse` and owns its wire knowledge: which hook type carries JSON on stdout, the exit code, and when text routes to stderr. The Cursor per-hook schema switch moves into the cursor package.
- `cli/hook.go` collapses to one `sendResponse` routine. The stderr text travels on one channel only: inside the exit error for a non-zero exit (main writes it), or directly for exit zero. The three per-agent switches and seven handler functions are deleted.
- The `agent` package does not import `core/security`. The CLI maps `security.Result` to a `HookDecision`.

## Testing

- New: per-adapter `render_test.go` table tests over the hook type and decision matrix, livelog cycle and badge fallback tests, config map accessor and YAML binding tests, a test that an agent key absent from defaults binds from the config file.
- Unchanged and green: `test/cli/e2e_hook_matrix_test.go`, `e2e_hook_test.go`, `e2e_hook_policy_test.go`, and the acceptance suite. These pin the wire behavior.
- `go test ./... -count=1` passes. `make lint` reports 0 issues.

## Out of scope

- `collectSessionCost` in `cli/cost.go` keeps its per-agent switch. A cost collector capability on the adapter is a separate change.
- `IsAgentEnabled` has no production caller today. It stays as the config contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoUWpQafVnas5hKvTif6Nr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoUWpQafVnas5hKvTif6Nr)_