### PR TITLE
website: improve the learning wizard, mobile layout, hero, and policy authoring showcase

### DIFF
--- a/.claude/skills/gryph-policy-authoring/SKILL.md
+++ b/.claude/skills/gryph-policy-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gryph-policy-authoring
-description: Use when a human wants help to author or change a Gryph security policy that governs what an AI coding agent may do, often with an agent's help. Trigger whenever the user wants Gryph to block, allow, warn on, or require approval for an agent action, wants to write or change a policy rule, asks how to match a tool, command, file path, or URL, works with CEL conditions or context counters, wants to split policy into many files, or wants to dry-run a rule. Also trigger on phrases like "write a gryph policy", "add a policy rule", "make gryph block X", "help me write a policy", or "policy for my agent", even when the user does not name a file. This skill drafts a policy in a workspace directory and hands the user an install command. It never installs the policy and never writes into Gryph's config directory. It is not for changing the policy engine code (use aarm-policy-layer for engine work under aarm/ or cli/policy.go).
+description: Use when a human wants help to author or change a Gryph security policy that governs what an AI coding agent may do, often with an agent's help. Trigger whenever the user wants Gryph to block, allow, warn on, or require approval for an agent action, wants to write or change a policy rule, asks how to match a tool, command, file path, or URL, works with CEL conditions or context counters, wants to split policy into many files, or wants to dry-run a rule. Also trigger on phrases like "write a gryph policy", "add a policy rule", "make gryph block X", "help me write a policy", or "policy for my agent", even when the user does not name a file. This skill drafts a policy in a workspace directory and hands the user an install command. It never installs the policy and never writes into Gryph's config directory. It is not for changing the policy engine code.
 ---
 
 # Authoring Gryph Policies
@@ -34,10 +34,11 @@ the existing policy from it. Do not author fields from memory.
   to imitate, and to see what already fires so your rule does not collide with them.
 - `gryph policy list` shows every active source and its rule count.
 
-`docs/security-policy.md` in this repo is a concept guide. It explains match criteria,
-scope, CEL conditions, decisions, messages, receipts, and has worked examples. Read the
-section you need for concepts. When the doc and the binary disagree, trust the binary and
-tell the user.
+The security policy guide at
+https://github.com/safedep/gryph/blob/main/docs/security-policy.md is a concept guide.
+It explains match criteria, scope, CEL conditions, decisions, messages, receipts, and has
+worked examples. Read the section you need for concepts. When the doc and the binary
+disagree, trust the binary and tell the user.
 
 You may read the active policy for context: read the resolved `policy.yaml` (its path is
 printed by `gryph policy validate`) and the files in `policies/`. Read only. Never write

--- a/tui/table.go
+++ b/tui/table.go
@@ -752,6 +752,14 @@ func (p *TablePresenter) renderPayloadDetail(tw *tableWriter, payload any) {
 	}
 }
 
+// Cost table widths equal the sum of the printf column widths plus the
+// separating spaces in RenderCostSummary. Update them together.
+const (
+	costSessionTableWidth = 86
+	costModelTableWidth   = 96
+	costGroupTableWidth   = 47
+)
+
 // RenderCostSummary renders the cost summary.
 func (p *TablePresenter) RenderCostSummary(summary *CostSummaryView) error {
 	tw := &tableWriter{w: p.w}
@@ -764,12 +772,12 @@ func (p *TablePresenter) RenderCostSummary(summary *CostSummaryView) error {
 
 		tw.printf("%-10s %-14s %-10s %-21s %7s %8s %10s\n",
 			"SESSION", "AGENT", "PROJECT", "STARTED", "MODELS", "TOKENS", "COST")
-		tw.println(HorizontalLine(p.termWidth))
+		tw.println(HorizontalLine(costSessionTableWidth))
 
 		for _, s := range summary.Sessions {
-			tw.printf("%-10s %-14s %-10s %-21s %7d %8s %10s\n",
+			tw.printf("%-10s %s %-10s %-21s %7d %8s %10s\n",
 				s.ShortID,
-				p.color.Agent(s.AgentName),
+				PadRightVisible(p.color.Agent(s.AgentName), 14),
 				TruncateString(s.ProjectName, 10),
 				FormatTime(s.StartedAt),
 				s.ModelCount,
@@ -777,7 +785,7 @@ func (p *TablePresenter) RenderCostSummary(summary *CostSummaryView) error {
 				FormatCost(s.TotalCost))
 		}
 
-		tw.println(HorizontalLine(p.termWidth))
+		tw.println(HorizontalLine(costSessionTableWidth))
 		tw.printf("Total (%d sessions) %43s %10s\n",
 			summary.TotalSessions,
 			FormatTokens(summary.TotalTokens),
@@ -787,7 +795,7 @@ func (p *TablePresenter) RenderCostSummary(summary *CostSummaryView) error {
 		case "model":
 			tw.printf("%-30s %10s %10s %10s %10s %10s %10s\n",
 				"MODEL", "SESSIONS", "INPUT", "OUTPUT", "CACHE_R", "CACHE_W", "COST")
-			tw.println(HorizontalLine(p.termWidth))
+			tw.println(HorizontalLine(costModelTableWidth))
 			for _, g := range summary.Groups {
 				tw.printf("%-30s %10d %10s %10s %10s %10s %10s\n",
 					TruncateString(g.Label, 30),
@@ -798,7 +806,7 @@ func (p *TablePresenter) RenderCostSummary(summary *CostSummaryView) error {
 					FormatNumber64(g.CacheWrite),
 					FormatCost(g.TotalCost))
 			}
-			tw.println(HorizontalLine(p.termWidth))
+			tw.println(HorizontalLine(costModelTableWidth))
 			tw.printf("%-30s %10d %10s %10s %10s %10s %10s\n",
 				"Total",
 				summary.TotalSessions,
@@ -810,15 +818,15 @@ func (p *TablePresenter) RenderCostSummary(summary *CostSummaryView) error {
 
 		case "agent":
 			tw.printf("%-14s %10s %10s %10s\n", "AGENT", "SESSIONS", "TOKENS", "COST")
-			tw.println(HorizontalLine(p.termWidth))
+			tw.println(HorizontalLine(costGroupTableWidth))
 			for _, g := range summary.Groups {
-				tw.printf("%-14s %10d %10s %10s\n",
-					p.color.Agent(g.Label),
+				tw.printf("%s %10d %10s %10s\n",
+					PadRightVisible(p.color.Agent(g.Label), 14),
 					g.SessionCount,
 					FormatTokens(g.TotalTokens),
 					FormatCost(g.TotalCost))
 			}
-			tw.println(HorizontalLine(p.termWidth))
+			tw.println(HorizontalLine(costGroupTableWidth))
 			tw.printf("%-14s %10d %10s %10s\n",
 				"Total",
 				summary.TotalSessions,
@@ -827,7 +835,7 @@ func (p *TablePresenter) RenderCostSummary(summary *CostSummaryView) error {
 
 		case "day":
 			tw.printf("%-14s %10s %10s %10s\n", "DATE", "SESSIONS", "TOKENS", "COST")
-			tw.println(HorizontalLine(p.termWidth))
+			tw.println(HorizontalLine(costGroupTableWidth))
 			for _, g := range summary.Groups {
 				tw.printf("%-14s %10d %10s %10s\n",
 					g.Label,
@@ -835,7 +843,7 @@ func (p *TablePresenter) RenderCostSummary(summary *CostSummaryView) error {
 					FormatTokens(g.TotalTokens),
 					FormatCost(g.TotalCost))
 			}
-			tw.println(HorizontalLine(p.termWidth))
+			tw.println(HorizontalLine(costGroupTableWidth))
 			tw.printf("%-14s %10d %10s %10s\n",
 				"Total",
 				summary.TotalSessions,

--- a/tui/table_test.go
+++ b/tui/table_test.go
@@ -1,0 +1,62 @@
+package tui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func visibleRuneCount(line string) int {
+	return utf8.RuneCountInString(ansiRegex.ReplaceAllString(line, ""))
+}
+
+func renderCostSummary(t *testing.T, summary *CostSummaryView) []string {
+	t.Helper()
+	var buf bytes.Buffer
+	p := NewTablePresenter(PresenterOptions{Writer: &buf, UseColors: true, TerminalWidth: 200})
+	require.NoError(t, p.RenderCostSummary(summary))
+	return strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+}
+
+func TestRenderCostSummaryByAgentAlignsColoredNames(t *testing.T) {
+	lines := renderCostSummary(t, &CostSummaryView{
+		GroupBy: "agent",
+		Groups: []CostGroupView{
+			{Label: "claude-code", SessionCount: 68, TotalTokens: 1578400000, TotalCost: 19.18},
+			{Label: "codex", SessionCount: 9},
+		},
+		TotalSessions: 77,
+		TotalTokens:   1578400000,
+		TotalCost:     19.18,
+	})
+
+	require.Len(t, lines, 6)
+	for i, line := range lines {
+		assert.Equal(t, costGroupTableWidth, visibleRuneCount(line), "line %d: %q", i, line)
+	}
+}
+
+func TestRenderCostSummaryBySessionAlignsColoredNames(t *testing.T) {
+	lines := renderCostSummary(t, &CostSummaryView{
+		GroupBy: "session",
+		Sessions: []*CostSessionView{
+			{ShortID: "a91f", AgentName: "claude-code", ProjectName: "gryph",
+				StartedAt: time.Now(), ModelCount: 1, TotalTokens: 1200, TotalCost: 0.02},
+			{ShortID: "b23c", AgentName: "codex", ProjectName: "gryph",
+				StartedAt: time.Now(), ModelCount: 1, TotalTokens: 900, TotalCost: 0.01},
+		},
+		TotalSessions: 2,
+		TotalTokens:   2100,
+		TotalCost:     0.03,
+	})
+
+	require.GreaterOrEqual(t, len(lines), 5)
+	for i, line := range lines[:5] {
+		assert.Equal(t, costSessionTableWidth, visibleRuneCount(line), "line %d: %q", i, line)
+	}
+}

--- a/website/src/data/site.ts
+++ b/website/src/data/site.ts
@@ -21,6 +21,7 @@ export const RAIL_TITLES = [
   'Query and export',
   'Privacy and config',
   'Control policy',
+  'Agent authoring',
   'Receipts',
   'Cost and stats',
   'Housekeeping',
@@ -52,13 +53,14 @@ export const FEATURES = [
   { name: 'Integrate', desc: 'JSON Lines exports pipe into your dashboards and internal tools.' },
 ]
 
-export const SHOWCASE_TABS = ['Observe', 'Control', 'Verify', 'Integrate']
+export const SHOWCASE_TABS = ['Observe', 'Control', 'Verify', 'Integrate', 'Author']
 
 export const SHOWCASE_SUBS = [
   'a full session, reconstructed',
   'one policy, four decisions',
   'signed receipts, hash-chained',
   'json lines to anything',
+  'your agent drafts, you install',
 ]
 
 export const MILESTONES = [
@@ -67,6 +69,7 @@ export const MILESTONES = [
   { name: 'Queried', desc: 'audit trail rebuilt' },
   { name: 'Guarded', desc: 'rm -rf blocked in a test' },
   { name: 'Enforced', desc: 'block receipt recorded' },
+  { name: 'Authored', desc: 'agent drafted, you installed' },
   { name: 'Verified', desc: 'receipt chain correct' },
 ]
 
@@ -76,7 +79,7 @@ export interface ReceiptLine {
 }
 
 export const RECEIPT_LINES: ReceiptLine[] = [
-  { text: 'milestones ......... 6/6 \u2713', tone: 'normal' },
+  { text: 'milestones ......... 7/7 \u2713', tone: 'normal' },
   { text: 'agents hooked ...... 1', tone: 'normal' },
   { text: 'events captured .... 128', tone: 'normal' },
   { text: 'policy ............. enforcing', tone: 'normal' },

--- a/website/src/data/tracks.ts
+++ b/website/src/data/tracks.ts
@@ -272,6 +272,53 @@ export const TRACKS: Track[] = [
     takeaway: 'Start with warn. Change to block after you trust the rule.',
   },
   {
+    title: 'Author policy with your agent',
+    time: '20 min',
+    docs: 'security-policy.md',
+    goal: 'Install the authoring skill. Ask your agent for a rule. Review it. Then install it yourself.',
+    steps: [
+      {
+        label: 'Install the policy authoring skill for your agent.',
+        cmd: 'npx skills add safedep/gryph --skill gryph-policy-authoring',
+        expected:
+          'The skill installs for Claude Code, Cursor, and other agents. It teaches your agent the safe authoring workflow.',
+      },
+      {
+        label: 'Ask your agent for a rule. Paste this task.',
+        cmd: 'Write a gryph policy that blocks git push --force',
+        expected:
+          'The agent drafts in a workspace directory such as ./gryph-policy/. Gryph blocks agent writes to its own config directory by design.',
+      },
+      {
+        label: 'Check the draft yourself. Run the same test the agent ran. Use the file name your agent chose.',
+        cmd: 'gryph policy test --file ./gryph-policy/no-force-push.yaml --action command_exec --command "git push --force"',
+        expected:
+          'The result is block. The agent tests a match, a non-match, and a boundary case before it hands you the draft.',
+      },
+      {
+        label: 'Review the draft. Then install it yourself. The agent never installs.',
+        cmd: 'gryph policy install ./gryph-policy/no-force-push.yaml',
+        expected:
+          'Install checks the file against the merged policy. To roll back, remove the file from the policies directory.',
+      },
+    ],
+    checkpoint: {
+      cmd: 'gryph policy list',
+      prompt:
+        'The list shows your new file as an active policy source. You stayed in control of the install.',
+    },
+    quiz: {
+      q: 'Who installs the policy?',
+      opts: [
+        { text: 'The agent installs it after its tests pass.', correct: false },
+        { text: 'You install it. The agent drafts and tests.', correct: true },
+      ],
+      explain:
+        'The skill drafts in a workspace and hands you the install command. Gryph blocks agent writes to its config directory.',
+    },
+    takeaway: 'Your agent drafts and tests the policy. You review and install it.',
+  },
+  {
     title: 'Audit integrity and receipts',
     time: '15 min',
     docs: 'security-policy.md',

--- a/website/src/data/tracks.ts
+++ b/website/src/data/tracks.ts
@@ -94,7 +94,7 @@ export const TRACKS: Track[] = [
     title: 'Capture your first session',
     time: '15 min',
     docs: 'cli-reference.md',
-    goal: 'Record the actions of an agent. Then view them with logs and sessions.',
+    goal: 'Watch the actions of an agent live. Then view the stored records.',
     steps: [
       {
         label: 'Make a temporary test project.',
@@ -102,20 +102,23 @@ export const TRACKS: Track[] = [
         expected: 'Use a clean directory for practice. Do not use a real project.',
       },
       {
-        label: 'Start your agent in that directory. Give it a small task.',
-        cmd: 'echo "hello gryph" > readme.txt',
-        expected: 'The agent reads, writes, and runs commands. Gryph records each action.',
-      },
-      {
-        label: 'View recent actions by session.',
-        cmd: 'gryph logs --today',
-        expected: 'Gryph shows read, write, and command actions for each session.',
-      },
-      {
-        label: 'Open one session. Then watch new actions as they happen.',
-        cmd: 'gryph sessions && gryph logs --follow',
+        label: 'Start the live monitor.',
+        cmd: 'gryph logs --live',
         expected:
-          'The command shows the full session. Use --follow to see new actions. Use --live for a full screen view.',
+          'Gryph opens a full screen monitor. Use --follow for plain stream output that you can pipe.',
+      },
+      {
+        label:
+          'Open a second terminal. Start your agent in the sandbox directory. Ask the agent to do this task.',
+        cmd: 'echo "hello gryph" > readme.txt',
+        expected:
+          'The agent reads, writes, and runs commands. Each action shows in the monitor as it happens. Gryph records agent actions, not your own shell commands.',
+      },
+      {
+        label: 'Exit the monitor. Then view the stored records by session.',
+        cmd: 'gryph sessions && gryph logs --today',
+        expected:
+          'Gryph keeps each action in the local database. The output shows read, write, and command actions for each session.',
       },
     ],
     checkpoint: {
@@ -221,9 +224,9 @@ export const TRACKS: Track[] = [
   },
   {
     title: 'Enforce a security policy',
-    time: '30 min',
+    time: '35 min',
     docs: 'security-policy.md',
-    goal: 'Write a YAML policy. Test it. Then apply it.',
+    goal: 'Write a YAML policy. Test a CEL condition. Then apply the policy.',
     steps: [
       {
         label: 'Write a candidate rule file in your sandbox directory.',
@@ -241,6 +244,13 @@ export const TRACKS: Track[] = [
         expected: 'The result is block. Gryph shows the message.',
       },
       {
+        label:
+          'Test a CEL rule. The example policy warns when a session writes 25 files or more.',
+        cmd: 'gryph policy test --file /tmp/gryph-sandbox/candidate.yml --action file_write --path src/app.go --context-files-written 30',
+        expected:
+          'The result is warn from the rule warn-session-write-volume. Its condition is the CEL expression context.files_written >= 25. A condition can also read action fields such as action.injection_score.',
+      },
+      {
         label: 'Install the rule. Then turn on enforcement.',
         cmd: 'gryph policy install /tmp/gryph-sandbox/candidate.yml && gryph config set policy.enabled true',
         expected: 'Now every agent action passes through the policy.',
@@ -251,13 +261,13 @@ export const TRACKS: Track[] = [
       prompt: 'You see one block receipt or more. Gryph keeps the decision record.',
     },
     quiz: {
-      q: 'Which effect is the safe way to start?',
+      q: 'What can a CEL condition read?',
       opts: [
-        { text: 'Block every action at once.', correct: false },
-        { text: 'Warn first. Change to block after you trust the rule.', correct: true },
+        { text: 'Only the fields of the current action.', correct: false },
+        { text: 'The action fields and the session context counters.', correct: true },
       ],
       explain:
-        'Rules can allow, warn, guide, block, escalate, or defer. Start with warn. Change to block later.',
+        'A condition reads action fields such as action.injection_score. It also reads session counters such as context.files_written. Start with warn. Change to block after you trust the rule.',
     },
     takeaway: 'Start with warn. Change to block after you trust the rule.',
   },

--- a/website/src/views/complete/completion.css
+++ b/website/src/views/complete/completion.css
@@ -154,3 +154,30 @@
   background: var(--card);
   color: var(--ink);
 }
+
+@media (max-width: 720px) {
+  .completion {
+    padding: 24px 14px;
+  }
+
+  .completion-receipt {
+    padding: 18px 16px;
+  }
+
+  .completion-body {
+    padding: 26px 18px 28px;
+  }
+
+  .completion-title {
+    font-size: 26px;
+  }
+
+  .milestone {
+    flex-wrap: wrap;
+    row-gap: 2px;
+  }
+
+  .completion-links {
+    flex-wrap: wrap;
+  }
+}

--- a/website/src/views/landing/Hero.tsx
+++ b/website/src/views/landing/Hero.tsx
@@ -35,7 +35,7 @@ export function Hero({ onStart }: { onStart: () => void }) {
         protect your agents {ARROW_NEXT}
       </button>
       <div className="hero-meta">
-        30 minutes {MIDDOT} 8 tracks {MIDDOT} runs on your machine
+        9 tracks {MIDDOT} self-paced {MIDDOT} runs on your machine
       </div>
     </section>
   )

--- a/website/src/views/landing/Hero.tsx
+++ b/website/src/views/landing/Hero.tsx
@@ -1,3 +1,5 @@
+import { Card } from '../../components/Card'
+import { BlinkCursor } from '../../components/BlinkCursor'
 import { ARROW_NEXT, MIDDOT } from '../../data/glyphs'
 
 export function Hero({ onStart }: { onStart: () => void }) {
@@ -8,28 +10,26 @@ export function Hero({ onStart }: { onStart: () => void }) {
         Your agents.
         <br />
         your controls.
+        <BlinkCursor />
       </h1>
       <p className="hero-desc">
-        An AI coding agent reads files, writes files, searches the web, calls tools, and runs
-        commands with no common record and no limit. Gryph adds the two primitives it does not
-        have. It records every action in a local database. It provides a powerful policy layer to
-        block, guide, or influence agent actions.
+        An AI coding agent reads, writes, and runs commands with no record and no limit. Gryph
+        records every action and enforces your policy before the action runs.
       </p>
-      <div className="hero-planes">
-        <div className="hero-plane">
-          <div className="hero-plane-name">Observe</div>
-          <div className="hero-plane-desc">
-            Gryph maintains a record of every action your agents take. You can see what they did,
-            when, and why.
+      <div className="hero-term">
+        <Card title="gryph logs --live">
+          <div>
+            <span className="badge badge-allow">ALLOW</span> write readme.txt
           </div>
-        </div>
-        <div className="hero-plane">
-          <div className="hero-plane-name">Control</div>
-          <div className="hero-plane-desc">
-            Gryph can block, warn, or guide an action. It makes the decision before the action
-            runs based on your policies.
+          <div>
+            <span className="badge badge-block">BLOCK</span> exec rm -rf /
           </div>
-        </div>
+          <div className="term-note">policy: no-destructive {MIDDOT} claude-code</div>
+          <div>
+            <span className="badge badge-allow">ALLOW</span> read src/main.go
+            <BlinkCursor />
+          </div>
+        </Card>
       </div>
       <button type="button" className="hero-cta" onClick={onStart}>
         protect your agents {ARROW_NEXT}

--- a/website/src/views/landing/Showcase.tsx
+++ b/website/src/views/landing/Showcase.tsx
@@ -29,8 +29,60 @@ export function Showcase() {
       {tab === 1 && <ControlPanels />}
       {tab === 2 && <VerifyPanels />}
       {tab === 3 && <IntegratePanels />}
+      {tab === 4 && <AuthorPanels />}
       <FeatureGrid />
     </section>
+  )
+}
+
+function AuthorPanels() {
+  return (
+    <div className="showcase-grid">
+      <Card title="your agent drafts">
+        <div>
+          <span className="term-dim">&gt;</span> make gryph block force pushes
+        </div>
+        <div className="term-gap term-dim">drafting gryph-policy/force-push.yaml</div>
+        <div>
+          <span className="term-dim">$</span> gryph policy validate --file {ELLIPSIS}
+        </div>
+        <div className="term-indent">
+          valid <span className="term-red">{CHECK}</span>
+        </div>
+        <div>
+          <span className="term-dim">$</span> gryph policy test {ELLIPSIS} --force
+        </div>
+        <div className="term-indent">
+          <span className="badge badge-block">BLOCK</span> no-force-push
+        </div>
+        <div className="term-gap">
+          run: <span className="term-bold">gryph policy install</span>
+        </div>
+      </Card>
+      <Card title="you install">
+        <div>
+          <span className="term-dim">$</span> gryph policy install force-push.yaml
+        </div>
+        <div className="term-indent">
+          installed to policies <span className="term-red">{CHECK}</span>
+        </div>
+        <div className="term-gap">
+          <span className="term-dim">$</span> gryph policy list
+        </div>
+        <div className="term-indent">
+          {`builtin${NBSP.repeat(9)} `}
+          <span className="term-dim">12 rules</span>
+        </div>
+        <div className="term-indent">
+          {`force-push.yaml${NBSP} `}
+          <span className="term-dim">1 rule</span>
+        </div>
+        <div className="term-gap term-dim">
+          roll back: remove the file
+          <BlinkCursor />
+        </div>
+      </Card>
+    </div>
   )
 }
 

--- a/website/src/views/landing/Showcase.tsx
+++ b/website/src/views/landing/Showcase.tsx
@@ -50,7 +50,7 @@ function AuthorPanels() {
           valid <span className="term-red">{CHECK}</span>
         </div>
         <div>
-          <span className="term-dim">$</span> gryph policy test {ELLIPSIS} --force
+          <span className="term-dim">$</span> gryph policy test {ELLIPSIS} "git push --force"
         </div>
         <div className="term-indent">
           <span className="badge badge-block">BLOCK</span> no-force-push
@@ -61,8 +61,9 @@ function AuthorPanels() {
       </Card>
       <Card title="you install">
         <div>
-          <span className="term-dim">$</span> gryph policy install force-push.yaml
+          <span className="term-dim">$</span> gryph policy install \
         </div>
+        <div className="term-indent-2">gryph-policy/force-push.yaml</div>
         <div className="term-indent">
           installed to policies <span className="term-red">{CHECK}</span>
         </div>

--- a/website/src/views/landing/landing.css
+++ b/website/src/views/landing/landing.css
@@ -39,7 +39,7 @@
   margin: 0 auto 28px;
   font-family: var(--font-sans);
   font-weight: 800;
-  font-size: 58px;
+  font-size: clamp(36px, 11vw, 58px);
   line-height: 0.94;
   letter-spacing: -0.035em;
   text-transform: capitalize;
@@ -347,4 +347,72 @@
 
 .landing-footer a:hover {
   color: var(--ink);
+}
+
+@media (max-width: 720px) {
+  .landing {
+    padding: 0 18px;
+  }
+
+  .hero {
+    padding: 44px 0 8px;
+  }
+
+  .hero-desc {
+    text-align: left;
+  }
+
+  .showcase {
+    padding: 48px 0 32px;
+  }
+
+  .showcase-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 100%;
+  }
+
+  .showcase-tab + .showcase-tab {
+    border-left: 0;
+  }
+
+  .showcase-tab:nth-child(2n) {
+    border-left: 2px solid var(--ink);
+  }
+
+  .showcase-tab:nth-child(n + 3) {
+    border-top: 2px solid var(--ink);
+  }
+
+  .showcase-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .term-note {
+    padding-left: 14px;
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .feature-cell + .feature-cell {
+    border-left: 0;
+  }
+
+  .feature-cell:nth-child(2n) {
+    border-left: 2px solid var(--ink);
+  }
+
+  .feature-cell:nth-child(n + 3) {
+    border-top: 2px solid var(--ink);
+  }
+
+  .local-callout {
+    padding: 20px;
+  }
+
+  .local-title {
+    font-size: 21px;
+  }
 }

--- a/website/src/views/landing/landing.css
+++ b/website/src/views/landing/landing.css
@@ -47,42 +47,25 @@
   text-wrap: balance;
 }
 
+.hero-title .blink-cursor {
+  width: 0.2em;
+  height: 0.68em;
+  vertical-align: -0.03em;
+  margin-left: 0.08em;
+}
+
 .hero-desc {
   margin: 0 auto 30px;
   font-size: 13.5px;
   line-height: 1.65;
   color: var(--muted);
   max-width: 470px;
-  text-align: justify;
 }
 
-.hero-planes {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
+.hero-term {
   max-width: 520px;
-  margin: 0 auto 30px;
+  margin: 0 auto 34px;
   text-align: left;
-}
-
-.hero-plane {
-  padding: 14px 16px;
-  border: 2px solid var(--ink);
-  background: var(--card);
-}
-
-.hero-plane-name {
-  font-family: var(--font-sans);
-  font-weight: 800;
-  font-size: 13px;
-  text-transform: uppercase;
-  margin-bottom: 5px;
-}
-
-.hero-plane-desc {
-  font-size: 11.5px;
-  line-height: 1.5;
-  color: var(--muted);
 }
 
 .hero-cta {
@@ -356,10 +339,6 @@
 
   .hero {
     padding: 44px 0 8px;
-  }
-
-  .hero-desc {
-    text-align: left;
   }
 
   .showcase {

--- a/website/src/views/wizard/wizard.css
+++ b/website/src/views/wizard/wizard.css
@@ -475,3 +475,77 @@
   cursor: not-allowed;
   box-shadow: none;
 }
+
+@media (max-width: 720px) {
+  .wizard-header-row {
+    padding: 0 14px;
+    gap: 10px;
+  }
+
+  .wizard-header-label {
+    flex: 0 1 auto;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .wizard-body {
+    grid-template-columns: 1fr;
+  }
+
+  .rail {
+    border-right: 0;
+    border-bottom: 2px solid var(--ink);
+    padding: 10px 14px;
+    overflow-x: auto;
+  }
+
+  .rail-label {
+    display: none;
+  }
+
+  .rail-items {
+    display: flex;
+    gap: 6px;
+  }
+
+  .rail-item {
+    width: auto;
+    flex: none;
+    padding: 5px 6px;
+  }
+
+  .rail-title {
+    display: none;
+  }
+
+  .rail-item-current .rail-title {
+    display: block;
+    color: var(--ink);
+  }
+
+  .wizard-main {
+    padding: 22px 16px 30px;
+  }
+
+  .track-title {
+    font-size: 25px;
+  }
+
+  .steptrack .track-title {
+    font-size: 23px;
+  }
+
+  .orientation-planes {
+    grid-template-columns: 1fr;
+  }
+
+  .checkpoint-takeaway {
+    grid-template-columns: 1fr;
+  }
+
+  .quiz-options {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## What this changes

Five commits. Four change the website. One makes the policy authoring skill work outside this repo.

### Wizard content

- Track 2 starts the live monitor (`gryph logs --live`) before the agent task. The user watches actions in real time, then reads the stored records. The old flow asked the user to run the sample task in their own shell, which Gryph does not record.
- Track 5 adds a CEL step. It fires `warn-session-write-volume` with `--context-files-written 30` and points at `action.injection_score`. The quiz now asks what a CEL condition can read.
- New track 6, "Author policy with your agent". The user installs the authoring skill with `npx skills add safedep/gryph --skill gryph-policy-authoring`, asks their agent for a rule, re-runs the agent's test, and installs the draft themselves. The checkpoint confirms the new policy source with `gryph policy list`. Rollback is in the step text.

### Mobile layout

The stylesheets had no media queries. On a phone the wizard kept the 250px module rail and pushed the lesson off screen. This adds one narrow-screen block per stylesheet. The wizard stacks to one column with a horizontal badge rail. The landing feature grid and showcase tabs wrap to two columns. Verified at 390px width: no view overflows.

### Hero and showcase

- The hero shows a small `gryph logs --live` terminal card with a block decision, in place of the two Observe and Control cards that repeat in the feature grid. The paragraph is cut to two sentences.
- New "Author" showcase tab. One card shows the agent drafting and testing a rule. The other shows the human running the install and the rollback path.

### Skill

`SKILL.md` referenced `docs/security-policy.md` "in this repo" and the repo-internal `aarm-policy-layer` skill. Both references are now context free, so the skill works when `npx skills add` installs it on a user machine.

## Verification

- `tsc --noEmit` and `vite build` pass.
- Headless Chromium walk at 390px width: landing, orientation, all 9 tracks, completion. Every view measures 390px scroll width.
- Desktop render at 1280px is unchanged apart from the hero and the new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fo3tAeMbZbYHaXBC4ZfTvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fo3tAeMbZbYHaXBC4ZfTvr)_